### PR TITLE
chore: upgrade parent POM to v66 and reformat Java sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>52</version>
+        <version>66</version>
         <relativePath />
     </parent>
 
@@ -31,30 +31,18 @@
     <version>3.2.1-SNAPSHOT</version>
 
     <name>Apache Sling JCR Base</name>
-    <description>
-		The JCR base bundle provides JCR utility classes
-    </description>
+    <description>The JCR base bundle provides JCR utility classes</description>
 
     <scm>
         <connection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-jcr-base.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-jcr-base.git</developerConnection>
+        <tag>HEAD</tag>
         <url>https://github.com/apache/sling-org-apache-sling-jcr-base.git</url>
-    <tag>HEAD</tag>
-  </scm>
+    </scm>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <excludePackageNames>
-                        org.apache.sling.jcr.base.internal
-                    </excludePackageNames>
-                </configuration>
-	        </plugin>
-        </plugins>
-    </build>
+    <properties>
+        <sling.java.version>8</sling.java.version>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -175,5 +163,17 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <excludePackageNames>org.apache.sling.jcr.base.internal</excludePackageNames>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/src/main/java/org/apache/sling/jcr/base/AbstractSlingRepository2.java
+++ b/src/main/java/org/apache/sling/jcr/base/AbstractSlingRepository2.java
@@ -18,12 +18,6 @@
  */
 package org.apache.sling.jcr.base;
 
-import java.security.Principal;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 import javax.jcr.Credentials;
 import javax.jcr.GuestCredentials;
 import javax.jcr.LoginException;
@@ -35,6 +29,13 @@ import javax.jcr.SimpleCredentials;
 import javax.jcr.Value;
 import javax.security.auth.Subject;
 
+import java.security.Principal;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.apache.sling.jcr.api.SlingRepository;
 import org.apache.sling.jcr.base.internal.mount.ProxyRepository;
 import org.apache.sling.serviceusermapping.ServiceUserMapper;
@@ -44,25 +45,21 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The <code>AbstractSlingRepository2</code> is an abstract implementation of
- * the {@link SlingRepository} version 2.3 interface (phasing
- * {@link #loginAdministrative(String)} out in favor of
- * {@link #loginService(String, String)}) which provides default support for
- * attached repositories.
- * 
- * Implementations of the <code>SlingRepository</code> interface may wish to
- * extend this class to benefit from default implementations of most methods.
- * 
- * To be able to know the calling bundle to implement the
- * {@link #loginService(String, String)} method the bundle using the repository
- * service has to be provided in the
- * {@link #AbstractSlingRepository2(AbstractSlingRepositoryManager, Bundle)
- * constructor}.
- * 
- * The premise of this abstract class is that an instance of an implementation
- * of this abstract class is handed out to each consumer of the
- * {@code SlingRepository} service. Each instance is generally based on the same
- * {@link #getRepository() delegated repository} instance.
+ * The <code>AbstractSlingRepository2</code> is an abstract implementation of the {@link
+ * SlingRepository} version 2.3 interface (phasing {@link #loginAdministrative(String)} out in favor
+ * of {@link #loginService(String, String)}) which provides default support for attached
+ * repositories.
+ *
+ * <p>Implementations of the <code>SlingRepository</code> interface may wish to extend this class to
+ * benefit from default implementations of most methods.
+ *
+ * <p>To be able to know the calling bundle to implement the {@link #loginService(String, String)}
+ * method the bundle using the repository service has to be provided in the {@link
+ * #AbstractSlingRepository2(AbstractSlingRepositoryManager, Bundle) constructor}.
+ *
+ * <p>The premise of this abstract class is that an instance of an implementation of this abstract
+ * class is handed out to each consumer of the {@code SlingRepository} service. Each instance is
+ * generally based on the same {@link #getRepository() delegated repository} instance.
  *
  * @see AbstractSlingRepositoryManager
  * @since API version 2.4 (bundle version 2.3)
@@ -82,33 +79,31 @@ public abstract class AbstractSlingRepository2 implements SlingRepository {
     /**
      * Sets up this abstract SlingRepository implementation.
      *
-     * @param manager The {@link AbstractSlingRepositoryManager} controlling
-     *            this instance as well as the actual JCR repository instance
-     *            used by this.
-     * @param usingBundle The bundle using this instance. This is used by the
-     *            {@link #loginService(String, String)} method, which will not
-     *            be able to login if this parameter is {@code null}
+     * @param manager The {@link AbstractSlingRepositoryManager} controlling this instance as well as
+     *     the actual JCR repository instance used by this.
+     * @param usingBundle The bundle using this instance. This is used by the {@link
+     *     #loginService(String, String)} method, which will not be able to login if this parameter is
+     *     {@code null}
      */
     protected AbstractSlingRepository2(final AbstractSlingRepositoryManager manager, final Bundle usingBundle) {
         this.manager = manager;
         this.usingBundle = usingBundle;
 
-        if(usingBundle == null) {
+        if (usingBundle == null) {
             throw new IllegalArgumentException("usingBundle is null");
         }
     }
 
     /**
-     * @return The {@link AbstractSlingRepositoryManager} controlling this
-     *         instances
+     * @return The {@link AbstractSlingRepositoryManager} controlling this instances
      */
     protected final AbstractSlingRepositoryManager getSlingRepositoryManager() {
         return this.manager;
     }
 
     /**
-     * Returns the actual repository to which all JCR Repository interface
-     * methods implemented by this class are delegated.
+     * Returns the actual repository to which all JCR Repository interface methods implemented by this
+     * class are delegated.
      *
      * @return The delegated repository.
      */
@@ -117,12 +112,11 @@ public abstract class AbstractSlingRepository2 implements SlingRepository {
     }
 
     /**
-     * Returns the default workspace to login to if any of the {@code login} and
-     * {@code createSession} methods is called without an explicit workspace
-     * name.
-     * <p>
-     * This method may return {@code null} in which case the actual default
-     * workspace used depends on the underlying JCR Repository implementation.
+     * Returns the default workspace to login to if any of the {@code login} and {@code createSession}
+     * methods is called without an explicit workspace name.
+     *
+     * <p>This method may return {@code null} in which case the actual default workspace used depends
+     * on the underlying JCR Repository implementation.
      */
     @Override
     public final String getDefaultWorkspace() {
@@ -131,12 +125,12 @@ public abstract class AbstractSlingRepository2 implements SlingRepository {
 
     /**
      * Creates an administrative session to access the indicated workspace.
-     * <p>
-     * This method is called by the {@link #loginAdministrative(String)} and
-     * {@link #createServiceSession(String, String)} methods.
      *
-     * @param workspace The workspace to access or {@code null} to access the
-     *            {@link #getDefaultWorkspace() default workspace}
+     * <p>This method is called by the {@link #loginAdministrative(String)} and {@link
+     * #createServiceSession(String, String)} methods.
+     *
+     * @param workspace The workspace to access or {@code null} to access the {@link
+     *     #getDefaultWorkspace() default workspace}
      * @return An administrative session
      * @throws RepositoryException If a general error occurs during login
      * @see #createServiceSession(String, String)
@@ -144,24 +138,25 @@ public abstract class AbstractSlingRepository2 implements SlingRepository {
      */
     protected abstract Session createAdministrativeSession(final String workspace) throws RepositoryException;
 
-
     /**
-     * Creates a new service-session. This method is used by {@link #loginService(String, String)}
-     * and {@link #impersonateFromService(String, Credentials, String)} to avoid
-     * code duplication.
+     * Creates a new service-session. This method is used by {@link #loginService(String, String)} and
+     * {@link #impersonateFromService(String, Credentials, String)} to avoid code duplication.
      *
      * @param usingBundle The bundle using a service session.
      * @param subServiceName The optional name of the subservice.
      * @param workspaceName The JCR workspace name or {@code null}.
-     * @return A new service session or {@code null} if neither a user-name nor a
-     *         principal names mapping has been defined.
+     * @return A new service session or {@code null} if neither a user-name nor a principal names
+     *     mapping has been defined.
      * @throws RepositoryException If an error occurs while creating the service session.
      */
-    private Session createServiceSession(Bundle usingBundle, String subServiceName, String workspaceName) throws RepositoryException {
-        final ServiceUserMapper serviceUserMapper = this.getSlingRepositoryManager().getServiceUserMapper();
+    private Session createServiceSession(Bundle usingBundle, String subServiceName, String workspaceName)
+            throws RepositoryException {
+        final ServiceUserMapper serviceUserMapper =
+                this.getSlingRepositoryManager().getServiceUserMapper();
         if (serviceUserMapper != null) {
             Session session = null;
-            final Iterable<String> principalNames = serviceUserMapper.getServicePrincipalNames(usingBundle, subServiceName);
+            final Iterable<String> principalNames =
+                    serviceUserMapper.getServicePrincipalNames(usingBundle, subServiceName);
             if (principalNames != null) {
                 session = createServiceSession(principalNames, workspaceName);
             } else {
@@ -179,26 +174,23 @@ public abstract class AbstractSlingRepository2 implements SlingRepository {
     }
 
     /**
-     * Creates a service-session for the service's {@code serviceUserName} by
-     * impersonating the user from an administrative session.
-     * <p>
-     * The administrative session is created calling
-     * {@link #createAdministrativeSession(String)
-     * createAdministrativeSession(workspace)} and is logged out before this
-     * method returns.
-     * <p>
-     * Implementations of this class may overwrite this method with a better
-     * implementation, notably one which does not involve a temporary creation
-     * of an administrative session.
+     * Creates a service-session for the service's {@code serviceUserName} by impersonating the user
+     * from an administrative session.
+     *
+     * <p>The administrative session is created calling {@link #createAdministrativeSession(String)
+     * createAdministrativeSession(workspace)} and is logged out before this method returns.
+     *
+     * <p>Implementations of this class may overwrite this method with a better implementation,
+     * notably one which does not involve a temporary creation of an administrative session.
      *
      * @param serviceUserName The name of the user to create the session for
-     * @param workspace The workspace to access or {@code null} to access the
-     *            {@link #getDefaultWorkspace() default workspace}
+     * @param workspace The workspace to access or {@code null} to access the {@link
+     *     #getDefaultWorkspace() default workspace}
      * @return A session for the given user
-     * @throws RepositoryException If a general error occurs while creating the
-     *             session
+     * @throws RepositoryException If a general error occurs while creating the session
      */
-    protected Session createServiceSession(final String serviceUserName, final String workspace) throws RepositoryException {
+    protected Session createServiceSession(final String serviceUserName, final String workspace)
+            throws RepositoryException {
         Session admin = null;
         try {
             admin = this.createAdministrativeSession(workspace);
@@ -213,19 +205,21 @@ public abstract class AbstractSlingRepository2 implements SlingRepository {
     }
 
     /**
-     * Creates a service-session for the service's {@code servicePrincipalNames}
-     * using a pre-authenticated {@link Subject}.
-     * <p>
-     * Implementations of this class may overwrite this method to meet additional
-     * needs wrt the the nature of the principals, the {@code Subject} or additional
-     * attributes passed to the repository login.
+     * Creates a service-session for the service's {@code servicePrincipalNames} using a
+     * pre-authenticated {@link Subject}.
+     *
+     * <p>Implementations of this class may overwrite this method to meet additional needs wrt the the
+     * nature of the principals, the {@code Subject} or additional attributes passed to the repository
+     * login.
      *
      * @param servicePrincipalNames The names of the service principals to create the session for
-     * @param workspaceName The workspace to access or {@code null} to access the {@link #getDefaultWorkspace() default workspace}
+     * @param workspaceName The workspace to access or {@code null} to access the {@link
+     *     #getDefaultWorkspace() default workspace}
      * @return A new service session
      * @throws RepositoryException If a general error occurs while creating the session.
      */
-    protected Session createServiceSession(final Iterable<String> servicePrincipalNames, final String workspaceName) throws RepositoryException {
+    protected Session createServiceSession(final Iterable<String> servicePrincipalNames, final String workspaceName)
+            throws RepositoryException {
         Set<Principal> principals = new HashSet<>();
         for (final String pName : servicePrincipalNames) {
             if (pName != null && !pName.isEmpty()) {
@@ -236,15 +230,19 @@ public abstract class AbstractSlingRepository2 implements SlingRepository {
                     }
                 });
             }
-        };
+        }
+        ;
         Subject subject = new Subject(true, principals, Collections.emptySet(), Collections.emptySet());
         try {
-            return Subject.doAsPrivileged(subject, new PrivilegedExceptionAction<Session>() {
-                @Override
-                public Session run() throws Exception {
-                    return AbstractSlingRepository2.this.getRepository().login(null, workspaceName);
-                }
-            }, null);
+            return Subject.doAsPrivileged(
+                    subject,
+                    new PrivilegedExceptionAction<Session>() {
+                        @Override
+                        public Session run() throws Exception {
+                            return AbstractSlingRepository2.this.getRepository().login(null, workspaceName);
+                        }
+                    },
+                    null);
         } catch (PrivilegedActionException e) {
             throw new RepositoryException("failed to retrieve service session.", e);
         }
@@ -254,11 +252,10 @@ public abstract class AbstractSlingRepository2 implements SlingRepository {
 
     /**
      * Same as calling {@code login(null, null)}.
-     * <p>
-     * This method may be overwritten.
      *
-     * @return the result of calling {@link #login(Credentials, String)
-     *         login(null, null)}.
+     * <p>This method may be overwritten.
+     *
+     * @return the result of calling {@link #login(Credentials, String) login(null, null)}.
      * @throws LoginException If login is not possible
      * @throws RepositoryException If another error occurrs during login
      * @see #login(Credentials, String)
@@ -270,12 +267,11 @@ public abstract class AbstractSlingRepository2 implements SlingRepository {
 
     /**
      * Same as calling {@code login(credentials, null)}.
-     * <p>
-     * This method may be overwritten.
+     *
+     * <p>This method may be overwritten.
      *
      * @param credentials The {@code Credentials} to use to login.
-     * @return the result of calling {@link #login(Credentials, String)
-     *         login(credentials, null)}.
+     * @return the result of calling {@link #login(Credentials, String) login(credentials, null)}.
      * @throws LoginException If login is not possible
      * @throws RepositoryException If another error occurrs during login
      * @see #login(Credentials, String)
@@ -287,13 +283,12 @@ public abstract class AbstractSlingRepository2 implements SlingRepository {
 
     /**
      * Same as calling {@code login(null, workspace)}.
-     * <p>
-     * This method may be overwritten.
      *
-     * @param workspace The workspace to access or {@code null} to access the
-     *            {@link #getDefaultWorkspace() default workspace}
-     * @return the result of calling {@link #login(Credentials, String)
-     *         login(null, workspace)}.
+     * <p>This method may be overwritten.
+     *
+     * @param workspace The workspace to access or {@code null} to access the {@link
+     *     #getDefaultWorkspace() default workspace}
+     * @return the result of calling {@link #login(Credentials, String) login(null, workspace)}.
      * @throws LoginException If login is not possible
      * @throws RepositoryException If another error occurrs during login
      * @see #login(Credentials, String)
@@ -304,24 +299,21 @@ public abstract class AbstractSlingRepository2 implements SlingRepository {
     }
 
     /**
-     * Logs into the repository at the given {@code workspace} with the given
-     * {@code credentials} and returns the session returned from
-     * the repository.
-     * <p>
-     * This method logs in as a guest if {@code null} credentials are provided.
-     * The method may be overwritten to implement a different behaviour as
-     * indicated by the JCR specification for this method to use external
-     * mechanisms to login instead of leveraging provided credentials.
-     * <p>
-     * This method may be overwritten.
+     * Logs into the repository at the given {@code workspace} with the given {@code credentials} and
+     * returns the session returned from the repository.
      *
-     * @param credentials The {@code Credentials} to use to login. If this is
-     *            {@code null} JCR {@code GuestCredentials} are used to login.
-     * @param workspace The workspace to access or {@code null} to access the
-     *            {@link #getDefaultWorkspace() default workspace}
+     * <p>This method logs in as a guest if {@code null} credentials are provided. The method may be
+     * overwritten to implement a different behaviour as indicated by the JCR specification for this
+     * method to use external mechanisms to login instead of leveraging provided credentials.
+     *
+     * <p>This method may be overwritten.
+     *
+     * @param credentials The {@code Credentials} to use to login. If this is {@code null} JCR {@code
+     *     GuestCredentials} are used to login.
+     * @param workspace The workspace to access or {@code null} to access the {@link
+     *     #getDefaultWorkspace() default workspace}
      * @throws LoginException If login is not possible
-     * @throws NoSuchWorkspaceException if the desired workspace is not
-     *             available
+     * @throws NoSuchWorkspaceException if the desired workspace is not available
      * @throws RepositoryException If another error occurrs during login
      */
     @Override
@@ -357,25 +349,20 @@ public abstract class AbstractSlingRepository2 implements SlingRepository {
     // service login
 
     /**
-     * Actual implementation of the {@link #loginService(String, String)} method
-     * taking into account the bundle calling this method.
-     * 
-     * This method uses the
-     * {@link AbstractSlingRepositoryManager#getServiceUserMapper()
-     * ServiceUserMapper} service to map the named service to a user and then
-     * calls the {@link #createServiceSession(String, String)} method actually
-     * create a session for that user.
+     * Actual implementation of the {@link #loginService(String, String)} method taking into account
+     * the bundle calling this method.
      *
-     * @param subServiceName An optional subService identifier (may be
-     *            {@code null})
-     * @param workspace The workspace to access or {@code null} to access the
-     *            {@link #getDefaultWorkspace() default workspace}
+     * <p>This method uses the {@link AbstractSlingRepositoryManager#getServiceUserMapper()
+     * ServiceUserMapper} service to map the named service to a user and then calls the {@link
+     * #createServiceSession(String, String)} method actually create a session for that user.
+     *
+     * @param subServiceName An optional subService identifier (may be {@code null})
+     * @param workspace The workspace to access or {@code null} to access the {@link
+     *     #getDefaultWorkspace() default workspace}
      * @return A session authenticated with the service user
-     * @throws LoginException if the service name cannot be derived or if
-     *             logging is as the user to which the service name maps is not
-     *             allowed
-     * @throws RepositoryException If a general error occurs while creating the
-     *             session
+     * @throws LoginException if the service name cannot be derived or if logging is as the user to
+     *     which the service name maps is not allowed
+     * @throws RepositoryException If a general error occurs while creating the session
      */
     @Override
     public final Session loginService(final String subServiceName, final String workspace)
@@ -384,38 +371,45 @@ public abstract class AbstractSlingRepository2 implements SlingRepository {
         if (s != null) {
             return s;
         } else {
-            throw new LoginException("Can neither derive user name nor principal names for bundle " + usingBundle + " and sub service " + subServiceName);
+            throw new LoginException("Can neither derive user name nor principal names for bundle "
+                    + usingBundle
+                    + " and sub service "
+                    + subServiceName);
         }
     }
 
     /**
      * Default implementation of the {@link #impersonateFromService(String, Credentials, String)}
      * method taking into account the bundle calling this method.
-     * 
-     * This method uses the
-     * {@link AbstractSlingRepositoryManager#getServiceUserMapper()
-     * ServiceUserMapper} service to map the named service to a user and then
-     * calls the {@link #createServiceSession(String, String)} method actually
-     * create a session for that user. This service session is then impersonated
-     * to the subject identified by the specified {@code credentials}.
+     *
+     * <p>This method uses the {@link AbstractSlingRepositoryManager#getServiceUserMapper()
+     * ServiceUserMapper} service to map the named service to a user and then calls the {@link
+     * #createServiceSession(String, String)} method actually create a session for that user. This
+     * service session is then impersonated to the subject identified by the specified {@code
+     * credentials}.
      *
      * @param subServiceName An optional subService identifier (may be {@code null})
-     * @param credentials    A valid non-null {@code Credentials} object
-     * @param workspaceName  The workspace to access or {@code null} to access the
-     *            {@link #getDefaultWorkspace() default workspace}
+     * @param credentials A valid non-null {@code Credentials} object
+     * @param workspaceName The workspace to access or {@code null} to access the {@link
+     *     #getDefaultWorkspace() default workspace}
      * @return a new {@code Session} object
-     * @throws LoginException If the current session does not have sufficient access to perform the operation.
+     * @throws LoginException If the current session does not have sufficient access to perform the
+     *     operation.
      * @throws RepositoryException If another error occurs.
      * @since 2.4
      */
     @Override
-    public Session impersonateFromService(final String subServiceName, final Credentials credentials, final String workspaceName)
+    public Session impersonateFromService(
+            final String subServiceName, final Credentials credentials, final String workspaceName)
             throws LoginException, RepositoryException {
         Session serviceSession = null;
         try {
             serviceSession = createServiceSession(usingBundle, subServiceName, workspaceName);
             if (serviceSession == null) {
-                throw new LoginException("Cannot create service session for bundle " + usingBundle + " and sub service " + subServiceName);
+                throw new LoginException("Cannot create service session for bundle "
+                        + usingBundle
+                        + " and sub service "
+                        + subServiceName);
             }
             return serviceSession.impersonate(credentials);
         } finally {
@@ -425,17 +419,15 @@ public abstract class AbstractSlingRepository2 implements SlingRepository {
         }
     }
 
-
     /**
-     * Login as an administrative user. This method is deprecated and its use
-     * can be completely disabled by setting {@code disableLoginAdministrative}
-     * to {@code true}.
-     * <p>
-     * This implementation cannot be overwritten but, unless disabled, forwards
-     * to the {@link #createAdministrativeSession(String)} method.
+     * Login as an administrative user. This method is deprecated and its use can be completely
+     * disabled by setting {@code disableLoginAdministrative} to {@code true}.
      *
-     * @param workspace The workspace to access or {@code null} to access the
-     *            {@link #getDefaultWorkspace() default workspace}
+     * <p>This implementation cannot be overwritten but, unless disabled, forwards to the {@link
+     * #createAdministrativeSession(String)} method.
+     *
+     * @param workspace The workspace to access or {@code null} to access the {@link
+     *     #getDefaultWorkspace() default workspace}
      * @return An administrative session
      * @throws RepositoryException If the login fails or has been disabled
      */
@@ -443,16 +435,18 @@ public abstract class AbstractSlingRepository2 implements SlingRepository {
     public final Session loginAdministrative(final String workspace) throws RepositoryException {
         final boolean allowed = getSlingRepositoryManager().allowLoginAdministrativeForBundle(usingBundle);
 
-        if(!allowed) {
+        if (!allowed) {
             final String symbolicName = usingBundle.getSymbolicName();
             logger.error("Bundle {} is NOT allow listed to use SlingRepository.loginAdministrative", symbolicName);
-            throw new LoginException("Bundle " + symbolicName +" is NOT allow listed");
+            throw new LoginException("Bundle " + symbolicName + " is NOT allow listed");
         } else if (this.getSlingRepositoryManager().isDisableLoginAdministrative()) {
-            logger.error("SlingRepository.loginAdministrative is disabled. Please use SlingRepository.loginService.");
+            logger.error(
+                    "SlingRepository.loginAdministrative is disabled. Please use" + " SlingRepository.loginService.");
             throw new LoginException("SlingRepository.loginAdministrative is disabled.");
         }
 
-        logger.debug("SlingRepository.loginAdministrative is deprecated. Please use SlingRepository.loginService.");
+        logger.debug(
+                "SlingRepository.loginAdministrative is deprecated. Please use" + " SlingRepository.loginService.");
         Session result = createAdministrativeSession(workspace);
         Repository repository = getRepository();
         return repository instanceof ProxyRepository ? ((ProxyRepository) repository).wrap(result) : result;

--- a/src/main/java/org/apache/sling/jcr/base/AbstractSlingRepositoryManager.java
+++ b/src/main/java/org/apache/sling/jcr/base/AbstractSlingRepositoryManager.java
@@ -18,6 +18,8 @@
  */
 package org.apache.sling.jcr.base;
 
+import javax.jcr.Repository;
+
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Dictionary;
@@ -27,13 +29,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.jcr.Repository;
-
 import org.apache.jackrabbit.api.JackrabbitRepository;
 import org.apache.sling.jcr.api.SlingRepository;
 import org.apache.sling.jcr.api.SlingRepositoryInitializer;
-import org.apache.sling.jcr.base.internal.loader.Loader;
 import org.apache.sling.jcr.base.internal.LoginAdminAllowList;
+import org.apache.sling.jcr.base.internal.loader.Loader;
 import org.apache.sling.jcr.base.internal.mount.ProxyJackrabbitRepository;
 import org.apache.sling.jcr.base.internal.mount.ProxyRepository;
 import org.apache.sling.jcr.base.spi.RepositoryMount;
@@ -50,44 +50,44 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The <code>AbstractSlingRepositoryManager</code> is the basis for controlling
- * the JCR repository instances used by Sling. As a manager it starts and stops
- * the actual repository instance, manages service registration and hands out
- * {@code SlingRepository} instances to be used by the consumers.
- * <p>
- * This base class controls the livecycle of repository instance whereas
- * implementations of this class provide actual integration into the runtime
- * context. The livecycle of the repository instance is defined as follows:
- * <p>
- * To start the repository instance, the implementation calls the
- * {@link #start(BundleContext, String, boolean)}method which goes through the
- * steps of instantiating the repository, setting things up, and registering the
- * repository as an OSGi service:
+ * The <code>AbstractSlingRepositoryManager</code> is the basis for controlling the JCR repository
+ * instances used by Sling. As a manager it starts and stops the actual repository instance, manages
+ * service registration and hands out {@code SlingRepository} instances to be used by the consumers.
+ *
+ * <p>This base class controls the livecycle of repository instance whereas implementations of this
+ * class provide actual integration into the runtime context. The livecycle of the repository
+ * instance is defined as follows:
+ *
+ * <p>To start the repository instance, the implementation calls the {@link #start(BundleContext,
+ * String, boolean)}method which goes through the steps of instantiating the repository, setting
+ * things up, and registering the repository as an OSGi service:
+ *
  * <ol>
- * <li>{@link #acquireRepository()}</li>
- * <li>{@link #create(Bundle)}</li>
- * <li>{@link #registerService()}</li>
+ *   <li>{@link #acquireRepository()}
+ *   <li>{@link #create(Bundle)}
+ *   <li>{@link #registerService()}
  * </ol>
- * Earlier versions of this class had an additional <code>setup</code> method,
- * whatever code was there can be moved to the <code>create</code> method.
- * <p>
- * If starting the repository fails, the method {@link #stoppingOnError(String, Throwable)}
- * will be called. By default the exception is logged as an error, but this can
- * be customized by overwriting the method.
- * <p>
- * To stop the repository instance, the implementation calls the {@link #stop()}
- * method which goes through the steps of unregistering the OSGi service,
- * tearing all special settings down and finally shutting down the repository:
+ *
+ * Earlier versions of this class had an additional <code>setup</code> method, whatever code was
+ * there can be moved to the <code>create</code> method.
+ *
+ * <p>If starting the repository fails, the method {@link #stoppingOnError(String, Throwable)} will
+ * be called. By default the exception is logged as an error, but this can be customized by
+ * overwriting the method.
+ *
+ * <p>To stop the repository instance, the implementation calls the {@link #stop()} method which
+ * goes through the steps of unregistering the OSGi service, tearing all special settings down and
+ * finally shutting down the repository:
+ *
  * <ol>
- * <li>{@link #unregisterService(ServiceRegistration)}</li>
- * <li>{@link #destroy(AbstractSlingRepository2)}</li>
- * <li>{@link #disposeRepository(Repository)}</li>
+ *   <li>{@link #unregisterService(ServiceRegistration)}
+ *   <li>{@link #destroy(AbstractSlingRepository2)}
+ *   <li>{@link #disposeRepository(Repository)}
  * </ol>
- * <p>
- * Instances of this class manage a single repository instance backing the OSGi
- * service instances. Each consuming bundle, though, gets its own service
- * instance backed by the single actual repository instance managed by this
- * class.
+ *
+ * <p>Instances of this class manage a single repository instance backing the OSGi service
+ * instances. Each consuming bundle, though, gets its own service instance backed by the single
+ * actual repository instance managed by this class.
  *
  * @see AbstractSlingRepository2
  * @since API version 2.3 (bundle version 2.2.2)
@@ -97,8 +97,9 @@ public abstract class AbstractSlingRepositoryManager {
 
     private static final AtomicInteger startupCounter = new AtomicInteger();
 
-    private static final String INTERRUPTED_EXCEPTION_NOTE = "Avoid using Thread.interrupt() with Oak! See https://jackrabbit.apache.org/oak/docs/dos_and_donts.html .";
-    
+    private static final String INTERRUPTED_EXCEPTION_NOTE = "Avoid using Thread.interrupt() with Oak! See"
+            + " https://jackrabbit.apache.org/oak/docs/dos_and_donts.html .";
+
     /** default log */
     private final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -133,86 +134,76 @@ public abstract class AbstractSlingRepositoryManager {
     private volatile long startupThreadWaitMillis;
 
     /**
-     * Returns the default workspace, which may be <code>null</code> meaning to
-     * use the repository provided default workspace.
+     * Returns the default workspace, which may be <code>null</code> meaning to use the repository
+     * provided default workspace.
      *
-     * @return the default workspace or {@code null} indicating the repository's
-     *         default workspace is actually used.
+     * @return the default workspace or {@code null} indicating the repository's default workspace is
+     *     actually used.
      */
     public final String getDefaultWorkspace() {
         return defaultWorkspace;
     }
 
     /**
-     * Returns whether to disable the
-     * {@code SlingRepository.loginAdministrative} method or not.
+     * Returns whether to disable the {@code SlingRepository.loginAdministrative} method or not.
      *
-     * @return {@code true} if {@code SlingRepository.loginAdministrative} is
-     *         disabled.
+     * @return {@code true} if {@code SlingRepository.loginAdministrative} is disabled.
      */
     public final boolean isDisableLoginAdministrative() {
         return disableLoginAdministrative;
     }
 
     /**
-     * Returns the {@code ServiceUserMapper} service to map the service name to
-     * a service user name.
-     * <p>
-     * The {@code ServiceUserMapper} is used to implement the
-     * {@link AbstractSlingRepository2#loginService(String, String)} method used
-     * to replace the
-     * {@link AbstractSlingRepository2#loginAdministrative(String)} method. If
-     * this method returns {@code null} and hence the
-     * {@code ServiceUserMapperService} is not available, the
-     * {@code loginService} method is not able to login.
+     * Returns the {@code ServiceUserMapper} service to map the service name to a service user name.
      *
-     * @return The {@code ServiceUserMapper} service or {@code null} if not
-     *         available.
+     * <p>The {@code ServiceUserMapper} is used to implement the {@link
+     * AbstractSlingRepository2#loginService(String, String)} method used to replace the {@link
+     * AbstractSlingRepository2#loginAdministrative(String)} method. If this method returns {@code
+     * null} and hence the {@code ServiceUserMapperService} is not available, the {@code loginService}
+     * method is not able to login.
+     *
+     * @return The {@code ServiceUserMapper} service or {@code null} if not available.
      * @see AbstractSlingRepository2#loginService(String, String)
      */
     protected abstract ServiceUserMapper getServiceUserMapper();
 
     /**
-     * Returns whether or not the provided bundle is allowed to use
-     * {@link SlingRepository#loginAdministrative(String)}.
+     * Returns whether or not the provided bundle is allowed to use {@link
+     * SlingRepository#loginAdministrative(String)}.
      *
      * @param bundle The bundle requiring access to {@code loginAdministrative}
-     * @return A boolean value indicating whether or not the bundle is allowed
-     *         to use {@code loginAdministrative}.
+     * @return A boolean value indicating whether or not the bundle is allowed to use {@code
+     *     loginAdministrative}.
      */
     protected boolean allowLoginAdministrativeForBundle(final Bundle bundle) {
         return allowListTracker.getService().allowLoginAdministrative(bundle);
     }
 
     /**
-     * Creates the backing JCR repository instances. It is expected for this
-     * method to just start the repository.
-     * <p>
-     * This method does not throw any <code>Throwable</code> but instead just
-     * returns <code>null</code> if not repository is available. Any problems
-     * trying to acquire the repository must be caught and logged as
-     * appropriate.
+     * Creates the backing JCR repository instances. It is expected for this method to just start the
+     * repository.
      *
-     * @return The acquired JCR <code>Repository</code> or <code>null</code> if
-     *         not repository can be acquired.
+     * <p>This method does not throw any <code>Throwable</code> but instead just returns <code>null
+     * </code> if not repository is available. Any problems trying to acquire the repository must be
+     * caught and logged as appropriate.
+     *
+     * @return The acquired JCR <code>Repository</code> or <code>null</code> if not repository can be
+     *     acquired.
      * @see #start(BundleContext, String, boolean)
      */
     protected abstract Repository acquireRepository();
 
     /**
-     * Registers this component as an OSGi service with the types provided by
-     * the {@link #getServiceRegistrationInterfaces()} method and properties
-     * provided by the {@link #getServiceRegistrationProperties()} method.
-     * <p>
-     * The repository is actually registered as an OSGi {@code ServiceFactory}
-     * where the {@link #create(Bundle)} method is called to create an actual
-     * {@link AbstractSlingRepository2} repository instance for a calling
-     * (using) bundle. When the bundle is done using the repository instance,
-     * the {@link #destroy(AbstractSlingRepository2)} method is called to clean
-     * up.
+     * Registers this component as an OSGi service with the types provided by the {@link
+     * #getServiceRegistrationInterfaces()} method and properties provided by the {@link
+     * #getServiceRegistrationProperties()} method.
      *
-     * @return The OSGi <code>ServiceRegistration</code> object representing the
-     *         registered service.
+     * <p>The repository is actually registered as an OSGi {@code ServiceFactory} where the {@link
+     * #create(Bundle)} method is called to create an actual {@link AbstractSlingRepository2}
+     * repository instance for a calling (using) bundle. When the bundle is done using the repository
+     * instance, the {@link #destroy(AbstractSlingRepository2)} method is called to clean up.
+     *
+     * @return The OSGi <code>ServiceRegistration</code> object representing the registered service.
      * @see #start(BundleContext, String, boolean)
      * @see #getServiceRegistrationInterfaces()
      * @see #getServiceRegistrationProperties()
@@ -223,78 +214,80 @@ public abstract class AbstractSlingRepositoryManager {
         final Dictionary<String, Object> props = getServiceRegistrationProperties();
         final String[] interfaces = getServiceRegistrationInterfaces();
 
-        return bundleContext.registerService(interfaces, new ServiceFactory<AbstractSlingRepository2>() {
-            @Override
-            public AbstractSlingRepository2 getService(Bundle bundle, ServiceRegistration<AbstractSlingRepository2> registration) {
-                return AbstractSlingRepositoryManager.this.create(bundle);
-            }
+        return bundleContext.registerService(
+                interfaces,
+                new ServiceFactory<AbstractSlingRepository2>() {
+                    @Override
+                    public AbstractSlingRepository2 getService(
+                            Bundle bundle, ServiceRegistration<AbstractSlingRepository2> registration) {
+                        return AbstractSlingRepositoryManager.this.create(bundle);
+                    }
 
-            @Override
-            public void ungetService(Bundle bundle, ServiceRegistration<AbstractSlingRepository2> registration, AbstractSlingRepository2 service) {
-                AbstractSlingRepositoryManager.this.destroy(service);
-            }
-        }, props);
+                    @Override
+                    public void ungetService(
+                            Bundle bundle,
+                            ServiceRegistration<AbstractSlingRepository2> registration,
+                            AbstractSlingRepository2 service) {
+                        AbstractSlingRepositoryManager.this.destroy(service);
+                    }
+                },
+                props);
     }
 
     /**
-     * Return the service registration properties to be used to register the
-     * repository service in {@link #registerService()}.
+     * Return the service registration properties to be used to register the repository service in
+     * {@link #registerService()}.
      *
-     * @return The service registration properties to be used to register the
-     *         repository service in {@link #registerService()}
+     * @return The service registration properties to be used to register the repository service in
+     *     {@link #registerService()}
      * @see #registerService()
      */
     protected abstract Dictionary<String, Object> getServiceRegistrationProperties();
 
     /**
-     * Returns the service types to be used to register the repository service
-     * in {@link #registerService()}. All interfaces returned must be accessible
-     * to the class loader of the class of this instance.
-     * <p>
-     * This method may be overwritten to return additional types but the types
-     * returned from this base implementation, {@code SlingRepository} and
-     * {@code Repository}, must always be included.
+     * Returns the service types to be used to register the repository service in {@link
+     * #registerService()}. All interfaces returned must be accessible to the class loader of the
+     * class of this instance.
      *
-     * @return The service types to be used to register the repository service
-     *         in {@link #registerService()}
+     * <p>This method may be overwritten to return additional types but the types returned from this
+     * base implementation, {@code SlingRepository} and {@code Repository}, must always be included.
+     *
+     * @return The service types to be used to register the repository service in {@link
+     *     #registerService()}
      * @see #registerService()
      */
     protected String[] getServiceRegistrationInterfaces() {
-        return new String[] {
-            SlingRepository.class.getName(), Repository.class.getName()
-        };
+        return new String[] {SlingRepository.class.getName(), Repository.class.getName()};
     }
 
     /**
-     * Creates an instance of the {@link AbstractSlingRepository2}
-     * implementation for use by the given {@code usingBundle}.
-     * <p>
-     * This method is called when the repository service is requested from
-     * within the using bundle for the first time.
-     * <p>
-     * This method is expected to return a new instance on every call.
+     * Creates an instance of the {@link AbstractSlingRepository2} implementation for use by the given
+     * {@code usingBundle}.
      *
-     * @param usingBundle The bundle providing from which the repository is
-     *            requested.
-     * @return The {@link AbstractSlingRepository2} implementation instance to
-     *         be used by the {@code usingBundle}.
+     * <p>This method is called when the repository service is requested from within the using bundle
+     * for the first time.
+     *
+     * <p>This method is expected to return a new instance on every call.
+     *
+     * @param usingBundle The bundle providing from which the repository is requested.
+     * @return The {@link AbstractSlingRepository2} implementation instance to be used by the {@code
+     *     usingBundle}.
      * @see #registerService()
      */
     protected abstract AbstractSlingRepository2 create(Bundle usingBundle);
 
     /**
-     * Cleans up the given {@link AbstractSlingRepository2} instance previously
-     * created by the {@link #create(Bundle)} method.
+     * Cleans up the given {@link AbstractSlingRepository2} instance previously created by the {@link
+     * #create(Bundle)} method.
      *
-     * @param repositoryServiceInstance The {@link AbstractSlingRepository2}
-     *            istance to cleanup.
+     * @param repositoryServiceInstance The {@link AbstractSlingRepository2} istance to cleanup.
      * @see #registerService()
      */
     protected abstract void destroy(AbstractSlingRepository2 repositoryServiceInstance);
 
     /**
-     * Returns the repository underlying this instance or <code>null</code> if
-     * no repository is currently being available.
+     * Returns the repository underlying this instance or <code>null</code> if no repository is
+     * currently being available.
      *
      * @return The repository
      */
@@ -310,24 +303,22 @@ public abstract class AbstractSlingRepositoryManager {
                 for (String mount : ((String[]) mounts)) {
                     mountPoints.add(mount);
                 }
-            }
-            else {
+            } else {
                 mountPoints.add(mounts.toString());
             }
-        }
-        else {
+        } else {
             mountPoints.add("/content/jcrmount");
         }
-        return mountRepo != null ?
-            repository instanceof JackrabbitRepository ?
-                new ProxyJackrabbitRepository((JackrabbitRepository) repository, (JackrabbitRepository) mountRepo, mountPoints) :
-                new ProxyRepository<>(repository, mountRepo, mountPoints) :
-            repository;
+        return mountRepo != null
+                ? repository instanceof JackrabbitRepository
+                        ? new ProxyJackrabbitRepository(
+                                (JackrabbitRepository) repository, (JackrabbitRepository) mountRepo, mountPoints)
+                        : new ProxyRepository<>(repository, mountRepo, mountPoints)
+                : repository;
     }
 
     /**
-     * Unregisters the service represented by the
-     * <code>serviceRegistration</code>.
+     * Unregisters the service represented by the <code>serviceRegistration</code>.
      *
      * @param serviceRegistration The service to unregister
      */
@@ -338,16 +329,16 @@ public abstract class AbstractSlingRepositoryManager {
     /**
      * Disposes off the given <code>repository</code>.
      *
-     * @param repository The repository to be disposed off which is the same as
-     *            the one returned from {@link #acquireRepository()}.
+     * @param repository The repository to be disposed off which is the same as the one returned from
+     *     {@link #acquireRepository()}.
      */
     protected abstract void disposeRepository(Repository repository);
 
     /**
-     * Called when the repository service cannot be initialized or registered
-     * because an exception occurred.
-     * <p>
-     * This default implementation logs the exception as an error.
+     * Called when the repository service cannot be initialized or registered because an exception
+     * occurred.
+     *
+     * <p>This default implementation logs the exception as an error.
      *
      * @param message failure details.
      * @param t the exception.
@@ -362,29 +353,28 @@ public abstract class AbstractSlingRepositoryManager {
      * This method was deprecated with the introduction of asynchronous repository registration. With
      * asynchronous registration a boolean return value can no longer be guaranteed, as registration
      * may happen after the method returns.
-     * <p>
-     * Instead a {@link org.osgi.framework.ServiceListener} for {@link SlingRepository} may be
+     *
+     * <p>Instead a {@link org.osgi.framework.ServiceListener} for {@link SlingRepository} may be
      * registered to get informed about its successful registration.
      *
-     * @param bundleContext The {@code BundleContext} to register the repository
-     *            service (and optionally more services required to operate the
-     *            repository)
-     * @param defaultWorkspace The name of the default workspace to use to
-     *            login. This may be {@code null} to have the actual repository
-     *            instance define its own default
-     * @param disableLoginAdministrative Whether to disable the
-     *            {@code SlingRepository.loginAdministrative} method or not.
-     * @return {@code true} if the repository has been started and the service
-     *         is registered; {@code false} if the service has not been registered,
-     *         which may indicate that startup was unsuccessful OR that it is happening
-     *         asynchronously. A more reliable way to determin availability of the
-     *         {@link SlingRepository} as a service is using a
-     *         {@link org.osgi.framework.ServiceListener}.
+     * @param bundleContext The {@code BundleContext} to register the repository service (and
+     *     optionally more services required to operate the repository)
+     * @param defaultWorkspace The name of the default workspace to use to login. This may be {@code
+     *     null} to have the actual repository instance define its own default
+     * @param disableLoginAdministrative Whether to disable the {@code
+     *     SlingRepository.loginAdministrative} method or not.
+     * @return {@code true} if the repository has been started and the service is registered; {@code
+     *     false} if the service has not been registered, which may indicate that startup was
+     *     unsuccessful OR that it is happening asynchronously. A more reliable way to determin
+     *     availability of the {@link SlingRepository} as a service is using a {@link
+     *     org.osgi.framework.ServiceListener}.
      * @deprecated use {@link #start(BundleContext, AbstractSlingRepositoryManager.Config)} instead.
      */
     @Deprecated
-    protected final boolean start(final BundleContext bundleContext, final String defaultWorkspace,
-                                  final boolean disableLoginAdministrative) {
+    protected final boolean start(
+            final BundleContext bundleContext,
+            final String defaultWorkspace,
+            final boolean disableLoginAdministrative) {
         start(bundleContext, new Config(defaultWorkspace, disableLoginAdministrative));
         long end = System.currentTimeMillis() + 5000; // wait up to 5 seconds for repository registration
         while (!isRepositoryServiceRegistered() && end > System.currentTimeMillis()) {
@@ -398,47 +388,42 @@ public abstract class AbstractSlingRepositoryManager {
         return isRepositoryServiceRegistered();
     }
 
-    /**
-     * Configuration pojo to be passed to the {@link #start(BundleContext, Config)} method.
-     */
+    /** Configuration pojo to be passed to the {@link #start(BundleContext, Config)} method. */
     protected static final class Config {
 
         protected final String defaultWorkspace;
 
         protected final boolean disableLoginAdministrative;
-        
+
         protected final int startupThreadMaxWaitCount;
-        
+
         protected final long startupThreadWaitMillis;
 
         /**
-         * @param defaultWorkspace The name of the default workspace to use to
-         *            login. This may be {@code null} to have the actual repository
-         *            instance define its own default
-         *
-         * @param disableLoginAdministrative Whether to disable the
-         *            {@code SlingRepository.loginAdministrative} method or not.
+         * @param defaultWorkspace The name of the default workspace to use to login. This may be {@code
+         *     null} to have the actual repository instance define its own default
+         * @param disableLoginAdministrative Whether to disable the {@code
+         *     SlingRepository.loginAdministrative} method or not.
          */
         public Config(String defaultWorkspace, boolean disableLoginAdministrative) {
             this(defaultWorkspace, disableLoginAdministrative, 5, TimeUnit.MINUTES.toMillis(1));
         }
 
         /**
-         * @param defaultWorkspace The name of the default workspace to use to
-         *            login. This may be {@code null} to have the actual repository
-         *            instance define its own default
-         *
-         * @param disableLoginAdministrative Whether to disable the
-         *            {@code SlingRepository.loginAdministrative} method or not.
-         *            
-         * @param startupThreadMaxWaitCount The number of attempts to be performed
-         *            when waiting for the repository startup to complete
-         *            
-         * @param startupThreadWaitMillis The duration of each of the waits performed
-         *            when waiting for the repository startup to complete
+         * @param defaultWorkspace The name of the default workspace to use to login. This may be {@code
+         *     null} to have the actual repository instance define its own default
+         * @param disableLoginAdministrative Whether to disable the {@code
+         *     SlingRepository.loginAdministrative} method or not.
+         * @param startupThreadMaxWaitCount The number of attempts to be performed when waiting for the
+         *     repository startup to complete
+         * @param startupThreadWaitMillis The duration of each of the waits performed when waiting for
+         *     the repository startup to complete
          */
-        public Config(String defaultWorkspace, boolean disableLoginAdministrative, 
-                int startupThreadMaxWaitCount, long startupThreadWaitMillis) {
+        public Config(
+                String defaultWorkspace,
+                boolean disableLoginAdministrative,
+                int startupThreadMaxWaitCount,
+                long startupThreadWaitMillis) {
             this.defaultWorkspace = defaultWorkspace;
             this.disableLoginAdministrative = disableLoginAdministrative;
             this.startupThreadMaxWaitCount = startupThreadMaxWaitCount;
@@ -447,15 +432,14 @@ public abstract class AbstractSlingRepositoryManager {
     }
 
     /**
-     * This method actually starts the backing repository instannce and
-     * registeres the repository service.
-     * <p>
-     * Multiple subsequent calls to this method without calling {@link #stop()}
-     * first have no effect.
+     * This method actually starts the backing repository instannce and registeres the repository
+     * service.
      *
-     * @param bundleContext The {@code BundleContext} to register the repository
-     *            service (and optionally more services required to operate the
-     *            repository)
+     * <p>Multiple subsequent calls to this method without calling {@link #stop()} first have no
+     * effect.
+     *
+     * @param bundleContext The {@code BundleContext} to register the repository service (and
+     *     optionally more services required to operate the repository)
      * @param config The configuration to apply to this instance.
      */
     protected final void start(final BundleContext bundleContext, final Config config) {
@@ -475,16 +459,20 @@ public abstract class AbstractSlingRepositoryManager {
         this.mountTracker = new ServiceTracker<>(this.bundleContext, RepositoryMount.class, null);
         this.mountTracker.open();
 
-        this.repoInitializerTracker = new ServiceTracker<SlingRepositoryInitializer, SlingRepositoryInitializerInfo>(bundleContext, SlingRepositoryInitializer.class,
+        this.repoInitializerTracker = new ServiceTracker<SlingRepositoryInitializer, SlingRepositoryInitializerInfo>(
+                bundleContext,
+                SlingRepositoryInitializer.class,
                 new ServiceTrackerCustomizer<SlingRepositoryInitializer, SlingRepositoryInitializerInfo>() {
 
                     @Override
-                    public SlingRepositoryInitializerInfo addingService(final ServiceReference<SlingRepositoryInitializer> reference) {
+                    public SlingRepositoryInitializerInfo addingService(
+                            final ServiceReference<SlingRepositoryInitializer> reference) {
                         final SlingRepositoryInitializer service = bundleContext.getService(reference);
-                        if ( service != null ) {
-                            final SlingRepositoryInitializerInfo info = new SlingRepositoryInitializerInfo(service, reference);
-                            synchronized ( repoInitLock ) {
-                                if ( masterSlingRepository != null ) {
+                        if (service != null) {
+                            final SlingRepositoryInitializerInfo info =
+                                    new SlingRepositoryInitializerInfo(service, reference);
+                            synchronized (repoInitLock) {
+                                if (masterSlingRepository != null) {
                                     log.debug("Executing {}", info.initializer);
                                     try {
                                         info.initializer.processRepository(masterSlingRepository);
@@ -499,18 +487,19 @@ public abstract class AbstractSlingRepositoryManager {
                     }
 
                     @Override
-                    public void modifiedService(final ServiceReference<SlingRepositoryInitializer> reference,
+                    public void modifiedService(
+                            final ServiceReference<SlingRepositoryInitializer> reference,
                             final SlingRepositoryInitializerInfo service) {
                         // nothing to do
                     }
 
                     @Override
-                    public void removedService(final ServiceReference<SlingRepositoryInitializer> reference,
+                    public void removedService(
+                            final ServiceReference<SlingRepositoryInitializer> reference,
                             final SlingRepositoryInitializerInfo service) {
                         bundleContext.ungetService(reference);
                     }
-
-        });
+                });
         this.repoInitializerTracker.open();
 
         // If allowLoginAdministrativeForBundle is overridden we assume we don't need
@@ -520,16 +509,19 @@ public abstract class AbstractSlingRepositoryManager {
         boolean enableAllowlist = !isAllowLoginAdministrativeForBundleOverridden();
         final CountDownLatch waitForAllowList = new CountDownLatch(enableAllowlist ? 1 : 0);
         if (enableAllowlist) {
-            allowListTracker = new ServiceTracker<LoginAdminAllowList, LoginAdminAllowList>(bundleContext, LoginAdminAllowList.class, null) {
-                @Override
-                public LoginAdminAllowList addingService(final ServiceReference<LoginAdminAllowList> reference) {
-                    try {
-                        return super.addingService(reference);
-                    } finally {
-                        waitForAllowList.countDown();
-                    }
-                }
-            };
+            allowListTracker =
+                    new ServiceTracker<LoginAdminAllowList, LoginAdminAllowList>(
+                            bundleContext, LoginAdminAllowList.class, null) {
+                        @Override
+                        public LoginAdminAllowList addingService(
+                                final ServiceReference<LoginAdminAllowList> reference) {
+                            try {
+                                return super.addingService(reference);
+                            } finally {
+                                waitForAllowList.countDown();
+                            }
+                        }
+                    };
             allowListTracker.open();
         }
 
@@ -543,7 +535,12 @@ public abstract class AbstractSlingRepositoryManager {
                     waitForAllowList.await();
                     initializeAndRegisterRepositoryService();
                 } catch (InterruptedException e) {
-                    log.warn("Interrupted while waiting for the {} service, cancelling repository initialisation. {}", LoginAdminAllowList.class.getSimpleName(), INTERRUPTED_EXCEPTION_NOTE, e);
+                    log.warn(
+                            "Interrupted while waiting for the {} service, cancelling repository"
+                                    + " initialisation. {}",
+                            LoginAdminAllowList.class.getSimpleName(),
+                            INTERRUPTED_EXCEPTION_NOTE,
+                            e);
                     Thread.currentThread().interrupt();
                 }
             }
@@ -564,7 +561,7 @@ public abstract class AbstractSlingRepositoryManager {
                 // ensure we really have the repository
                 log.debug("start: got a Repository");
                 this.repository = newRepo;
-                synchronized ( this.repoInitLock ) {
+                synchronized (this.repoInitLock) {
                     this.masterSlingRepository = this.create(this.bundleContext.getBundle());
 
                     log.debug("start: setting up Loader");
@@ -573,8 +570,11 @@ public abstract class AbstractSlingRepositoryManager {
                     log.debug("start: calling SlingRepositoryInitializer");
                     try {
                         executeRepositoryInitializers(this.masterSlingRepository);
-                    } catch(Throwable e) {
-                        stoppingOnError("Exception in a SlingRepositoryInitializer, SlingRepository service registration aborted", e);
+                    } catch (Throwable e) {
+                        stoppingOnError(
+                                "Exception in a SlingRepositoryInitializer, SlingRepository service registration"
+                                        + " aborted",
+                                e);
                         stop();
                         return;
                     }
@@ -606,7 +606,7 @@ public abstract class AbstractSlingRepositoryManager {
             final Method[] declaredMethods = clazz.getDeclaredMethods();
             for (final Method method : declaredMethods) {
                 if (method.getName().equals("allowLoginAdministrativeForBundle")
-                        && Arrays.equals(method.getParameterTypes(), new Class<?>[]{Bundle.class})) {
+                        && Arrays.equals(method.getParameterTypes(), new Class<?>[] {Bundle.class})) {
                     return true;
                 }
             }
@@ -616,13 +616,14 @@ public abstract class AbstractSlingRepositoryManager {
     }
 
     private void executeRepositoryInitializers(final SlingRepository repo) throws Exception {
-        final SlingRepositoryInitializerInfo [] infos = repoInitializerTracker.getServices(new SlingRepositoryInitializerInfo[0]);
+        final SlingRepositoryInitializerInfo[] infos =
+                repoInitializerTracker.getServices(new SlingRepositoryInitializerInfo[0]);
         if (infos == null || infos.length == 0) {
             log.debug("No SlingRepositoryInitializer services found");
             return;
         }
         Arrays.sort(infos);
-        for(final SlingRepositoryInitializerInfo info : infos) {
+        for (final SlingRepositoryInitializerInfo info : infos) {
             log.debug("Executing {}", info.initializer);
             info.initializer.processRepository(repo);
         }
@@ -630,7 +631,7 @@ public abstract class AbstractSlingRepositoryManager {
 
     protected final void stop() {
         log.info("Stop requested");
-        if ( startupThread != null && startupThread != Thread.currentThread() ) {
+        if (startupThread != null && startupThread != Thread.currentThread()) {
             waitForStartupThreadToComplete();
             startupThread = null;
         }
@@ -649,7 +650,8 @@ public abstract class AbstractSlingRepositoryManager {
                 try {
                     if (isRepositoryServiceRegistered()) {
                         try {
-                            log.debug("stop: Unregistering SlingRepository service, registration={}", repositoryService);
+                            log.debug(
+                                    "stop: Unregistering SlingRepository service, registration={}", repositoryService);
                             unregisterService(repositoryService);
                         } catch (Throwable t) {
                             log.info("stop: Uncaught problem unregistering the repository service", t);
@@ -670,7 +672,8 @@ public abstract class AbstractSlingRepositoryManager {
                         this.destroy(this.masterSlingRepository);
 
                         try {
-                            disposeRepository(oldRepo instanceof  ProxyRepository ? ((ProxyRepository<?>) oldRepo).jcr : oldRepo);
+                            disposeRepository(
+                                    oldRepo instanceof ProxyRepository ? ((ProxyRepository<?>) oldRepo).jcr : oldRepo);
                         } catch (Throwable t) {
                             log.info("stop: Uncaught problem disposing the repository", t);
                         }
@@ -681,7 +684,7 @@ public abstract class AbstractSlingRepositoryManager {
             }
         }
 
-        if(repoInitializerTracker != null) {
+        if (repoInitializerTracker != null) {
             repoInitializerTracker.close();
             repoInitializerTracker = null;
         }
@@ -701,24 +704,36 @@ public abstract class AbstractSlingRepositoryManager {
         try {
             // Oak does play well with interrupted exceptions, so avoid that at all costs
             // https://jackrabbit.apache.org/oak/docs/dos_and_donts.html
-            for ( int i = 0; i < startupThreadMaxWaitCount; i++ ) {
-                log.info("Waiting {} millis for {} to complete, attempt {}/{}.", startupThreadWaitMillis, startupThread.getName(), (i + 1), startupThreadMaxWaitCount);
+            for (int i = 0; i < startupThreadMaxWaitCount; i++) {
+                log.info(
+                        "Waiting {} millis for {} to complete, attempt {}/{}.",
+                        startupThreadWaitMillis,
+                        startupThread.getName(),
+                        (i + 1),
+                        startupThreadMaxWaitCount);
                 startupThread.join(startupThreadWaitMillis);
-                if ( !startupThread.isAlive() ) {
+                if (!startupThread.isAlive()) {
                     log.info("{} not alive, proceeding", startupThread.getName());
                     break;
                 }
             }
         } catch (InterruptedException e) {
-            log.warn("Interrupted while waiting for the {} to complete. {}", startupThread.getName(), INTERRUPTED_EXCEPTION_NOTE, e);
+            log.warn(
+                    "Interrupted while waiting for the {} to complete. {}",
+                    startupThread.getName(),
+                    INTERRUPTED_EXCEPTION_NOTE,
+                    e);
             Thread.currentThread().interrupt();
         }
-        
-        if ( startupThread.isAlive() ) {
+
+        if (startupThread.isAlive()) {
             log.warn("Proceeding even though {} is still running, behaviour is undefined.", startupThread.getName());
-            if ( log.isInfoEnabled() ) {
+            if (log.isInfoEnabled()) {
                 StringBuilder stackTrace = new StringBuilder();
-                stackTrace.append("Stack trace for ").append(startupThread.getName()).append(" :\n");
+                stackTrace
+                        .append("Stack trace for ")
+                        .append(startupThread.getName())
+                        .append(" :\n");
                 for (StackTraceElement traceElement : startupThread.getStackTrace())
                     stackTrace.append("\tat ").append(traceElement).append('\n');
                 log.info(stackTrace.toString());
@@ -731,7 +746,8 @@ public abstract class AbstractSlingRepositoryManager {
         final SlingRepositoryInitializer initializer;
         final ServiceReference<SlingRepositoryInitializer> ref;
 
-        SlingRepositoryInitializerInfo(final SlingRepositoryInitializer init, ServiceReference<SlingRepositoryInitializer> ref) {
+        SlingRepositoryInitializerInfo(
+                final SlingRepositoryInitializer init, ServiceReference<SlingRepositoryInitializer> ref) {
             this.initializer = init;
             this.ref = ref;
         }

--- a/src/main/java/org/apache/sling/jcr/base/NodeTypeLoader.java
+++ b/src/main/java/org/apache/sling/jcr/base/NodeTypeLoader.java
@@ -18,15 +18,15 @@
  */
 package org.apache.sling.jcr.base;
 
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Workspace;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
-
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.jcr.Workspace;
 
 import org.apache.jackrabbit.commons.cnd.CndImporter;
 import org.apache.jackrabbit.commons.cnd.ParseException;
@@ -34,10 +34,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The <code>NodeTypeSupport</code> contains utility methods to register node
- * types from a <a href="http://jackrabbit.apache.org/doc/nodetype/cnd.html">CND
- * nodetype definition</a> file given as an URL or InputStream with the
- * repository.
+ * The <code>NodeTypeSupport</code> contains utility methods to register node types from a <a
+ * href="http://jackrabbit.apache.org/doc/nodetype/cnd.html">CND nodetype definition</a> file given
+ * as an URL or InputStream with the repository.
  */
 public class NodeTypeLoader {
 
@@ -45,19 +44,18 @@ public class NodeTypeLoader {
     private static final Logger log = LoggerFactory.getLogger(NodeTypeLoader.class);
 
     /**
-     * Registers node types from the CND file accessible by the <code>URL</code>
-     * with the node type manager available from the given <code>session</code>.
-     * <p>
-     * The <code>NodeTypeManager</code> returned by the <code>session</code>'s
-     * workspace is expected to be of type
-     * <code>org.apache.jackrabbit.api.JackrabbitNodeTypeManager</code> for
-     * the node type registration to succeed.
-     * <p>
-     * This method is not synchronized. It is up to the calling method to
-     * prevent paralell execution.
+     * Registers node types from the CND file accessible by the <code>URL</code> with the node type
+     * manager available from the given <code>session</code>.
      *
-     * @param session The <code>Session</code> providing the node type manager
-     *            through which the node type is to be registered.
+     * <p>The <code>NodeTypeManager</code> returned by the <code>session</code>'s workspace is
+     * expected to be of type <code>org.apache.jackrabbit.api.JackrabbitNodeTypeManager</code> for the
+     * node type registration to succeed.
+     *
+     * <p>This method is not synchronized. It is up to the calling method to prevent paralell
+     * execution.
+     *
+     * @param session The <code>Session</code> providing the node type manager through which the node
+     *     type is to be registered.
      * @param source The URL from which to read the CND file
      * @return <code>true</code> if registration of all node types succeeded.
      */
@@ -76,7 +74,7 @@ public class NodeTypeLoader {
         } catch (IOException ioe) {
             log.error("Cannot register node types from " + source, ioe);
         } catch (RepositoryException re) {
-            if(isReRegisterBuiltinNodeType(re)) {
+            if (isReRegisterBuiltinNodeType(re)) {
                 log.debug("Attempt to re-register built-in node type from " + source, re);
             } else {
                 log.error("Cannot register node types from " + source, re);
@@ -95,21 +93,19 @@ public class NodeTypeLoader {
     }
 
     /**
-     * Registers node types from the CND file read from the <code>source</code>
-     * with the node type manager available from the given <code>session</code>.
-     * <p>
-     * The <code>NodeTypeManager</code> returned by the <code>session</code>'s
-     * workspace is expected to be of type
-     * <code>org.apache.jackrabbit.api.JackrabbitNodeTypeManager</code> for
-     * the node type registration to succeed.
-     * <p>
-     * This method is not synchronized. It is up to the calling method to
-     * prevent paralell execution.
+     * Registers node types from the CND file read from the <code>source</code> with the node type
+     * manager available from the given <code>session</code>.
      *
-     * @param session The <code>Session</code> providing the node type manager
-     *            through which the node type is to be registered.
-     * @param source The <code>InputStream</code> from which the CND file is
-     *            read.
+     * <p>The <code>NodeTypeManager</code> returned by the <code>session</code>'s workspace is
+     * expected to be of type <code>org.apache.jackrabbit.api.JackrabbitNodeTypeManager</code> for the
+     * node type registration to succeed.
+     *
+     * <p>This method is not synchronized. It is up to the calling method to prevent paralell
+     * execution.
+     *
+     * @param session The <code>Session</code> providing the node type manager through which the node
+     *     type is to be registered.
+     * @param source The <code>InputStream</code> from which the CND file is read.
      * @return <code>true</code> if registration of all node types succeeded.
      * @throws IOException if there is an error parsing the input stream
      * @throws RepositoryException if another error occurs
@@ -120,12 +116,18 @@ public class NodeTypeLoader {
     }
 
     public static boolean registerNodeType(Session session, String systemId, Reader reader, boolean reregisterExisting)
-        throws IOException, RepositoryException {
+            throws IOException, RepositoryException {
         try {
             Workspace wsp = session.getWorkspace();
-            CndImporter.registerNodeTypes(reader, systemId, wsp.getNodeTypeManager(), wsp.getNamespaceRegistry(), session.getValueFactory(), reregisterExisting);
-        } catch(RepositoryException re) {
-            if(isReRegisterBuiltinNodeType(re)) {
+            CndImporter.registerNodeTypes(
+                    reader,
+                    systemId,
+                    wsp.getNodeTypeManager(),
+                    wsp.getNamespaceRegistry(),
+                    session.getValueFactory(),
+                    reregisterExisting);
+        } catch (RepositoryException re) {
+            if (isReRegisterBuiltinNodeType(re)) {
                 log.debug("Attempt to re-register built-in node type, RepositoryException ignored", re);
             } else {
                 throw re;
@@ -135,11 +137,10 @@ public class NodeTypeLoader {
         }
         return true;
     }
-    
+
     /** True if we think e was caused by an attempt to reregister a built-in node type */
     static boolean isReRegisterBuiltinNodeType(Exception e) {
-        return 
-            (e instanceof RepositoryException)
-            & (e.getMessage() != null && e.getMessage().contains("reregister built-in node type"));
+        return (e instanceof RepositoryException)
+                & (e.getMessage() != null && e.getMessage().contains("reregister built-in node type"));
     }
 }

--- a/src/main/java/org/apache/sling/jcr/base/internal/AllowListFragment.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/AllowListFragment.java
@@ -18,6 +18,10 @@
  */
 package org.apache.sling.jcr.base.internal;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -25,29 +29,21 @@ import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
 import static java.util.Arrays.asList;
 
 @ObjectClassDefinition(
         name = "Apache Sling Login Admin Allow List Configuration Fragment",
-        description = "This list of Bundle Symbolic Names is added to the list of bundles which are allowed " +
-            "to use Administrative Login. The full list is built in a modular way out of all such configuration fragments."
-)
+        description = "This list of Bundle Symbolic Names is added to the list of bundles which are allowed to"
+                + " use Administrative Login. The full list is built in a modular way out of all such"
+                + " configuration fragments.")
 @interface Configuration {
 
-    @AttributeDefinition(
-            name = "Name",
-            description = "Optional name to disambiguate configurations."
-    )
+    @AttributeDefinition(name = "Name", description = "Optional name to disambiguate configurations.")
     String allowlist_name() default "[unnamed]";
 
     @AttributeDefinition(
             name = "Allow listed BSNs",
-            description = "A list of bundle symbolic names allowed to use loginAdministrative()."
-    )
+            description = "A list of bundle symbolic names allowed to use loginAdministrative().")
     String[] allowlist_bundles();
 
     @SuppressWarnings({"unused", "java:S100"})
@@ -57,8 +53,7 @@ import static java.util.Arrays.asList;
 @Component(
         configurationPid = AllowListFragment.FACTORY_PID,
         configurationPolicy = ConfigurationPolicy.REQUIRE,
-        service = AllowListFragment.class
-)
+        service = AllowListFragment.class)
 @Designate(ocd = Configuration.class, factory = true)
 public class AllowListFragment {
 
@@ -70,6 +65,7 @@ public class AllowListFragment {
 
     /**
      * Constructor for SCR
+     *
      * @param config Configuration
      */
     @Activate
@@ -102,8 +98,7 @@ public class AllowListFragment {
             return false;
         }
         final AllowListFragment that = (AllowListFragment) o;
-        return name.equals(that.name)
-                && bundles.equals(that.bundles);
+        return name.equals(that.name) && bundles.equals(that.bundles);
     }
 
     @Override

--- a/src/main/java/org/apache/sling/jcr/base/internal/LegacyFragment.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/LegacyFragment.java
@@ -22,14 +22,11 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 
-/**
- * Legacy fragment configuration. Use {@link AllowListFragment} instead.
- */
+/** Legacy fragment configuration. Use {@link AllowListFragment} instead. */
 @Component(
         configurationPid = LegacyFragment.LEGACY_FACTORY_PID,
         configurationPolicy = ConfigurationPolicy.REQUIRE,
-        service = AllowListFragment.class
-)
+        service = AllowListFragment.class)
 public class LegacyFragment extends AllowListFragment {
 
     public static final String LEGACY_FACTORY_PID = "org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment";
@@ -42,12 +39,14 @@ public class LegacyFragment extends AllowListFragment {
         String[] whitelist_bundles();
     }
 
-
     @Activate
     public LegacyFragment(Configuration configuration) {
         super(configuration.whitelist_name(), configuration.whitelist_bundles());
-        LoginAdminAllowList.LOG.warn("Using deprecated factory configuration '{}' with whitelist.name='{}'. " +
-            "Update your configuration to use configuration '{}' instead.", 
-            LEGACY_FACTORY_PID, configuration.whitelist_name(), AllowListFragment.FACTORY_PID);
+        LoginAdminAllowList.LOG.warn(
+                "Using deprecated factory configuration '{}' with whitelist.name='{}'. "
+                        + "Update your configuration to use configuration '{}' instead.",
+                LEGACY_FACTORY_PID,
+                configuration.whitelist_name(),
+                AllowListFragment.FACTORY_PID);
     }
 }

--- a/src/main/java/org/apache/sling/jcr/base/internal/LoginAdminAllowList.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/LoginAdminAllowList.java
@@ -38,15 +38,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Allow list that defines which bundles can use the
- * {@link SlingRepository#loginAdministrative} method.
+ * Allow list that defines which bundles can use the {@link SlingRepository#loginAdministrative}
+ * method.
  *
- * The default configuration lets a few trusted Sling bundles
- * use the loginAdministrative method.
+ * <p>The default configuration lets a few trusted Sling bundles use the loginAdministrative method.
  */
-@Component(service = LoginAdminAllowList.class, 
-    configurationPid = {LoginAdminAllowList.PID, LoginAdminAllowList.LEGACY_PID}
-)
+@Component(
+        service = LoginAdminAllowList.class,
+        configurationPid = {LoginAdminAllowList.PID, LoginAdminAllowList.LEGACY_PID})
 public class LoginAdminAllowList {
 
     public static final String PID = "org.apache.sling.jcr.base.LoginAdminAllowList";
@@ -55,7 +54,8 @@ public class LoginAdminAllowList {
 
     static final Logger LOG = LoggerFactory.getLogger(LoginAdminAllowList.class);
 
-    // for backwards compatibility only (read properties directly to prevent them from appearing in the metatype)
+    // for backwards compatibility only (read properties directly to prevent them from appearing in
+    // the metatype)
     private static final String LEGACY_BYPASS_PROPERTY = "whitelist.bypass";
 
     private static final String LEGACY_BUNDLES_PROPERTY = "whitelist.bundles.regexp";
@@ -76,8 +76,7 @@ public class LoginAdminAllowList {
     @Reference(
             cardinality = ReferenceCardinality.MULTIPLE,
             policy = ReferencePolicy.DYNAMIC,
-            policyOption = ReferencePolicyOption.GREEDY
-    )
+            policyOption = ReferencePolicyOption.GREEDY)
     void bindAllowListFragment(AllowListFragment fragment) {
         allowListFragments.add(fragment);
         LOG.info("AllowListFragment added '{}'", fragment);
@@ -88,7 +87,8 @@ public class LoginAdminAllowList {
         LOG.info("AllowListFragment removed '{}'", fragment);
     }
 
-    @Activate @Modified
+    @Activate
+    @Modified
     void configure(final LoginAdminAllowListConfiguration configuration, final Map<String, Object> properties) {
         this.config = new ConfigurationState(configuration, properties);
         ensureBackwardsCompatibility(properties, PROP_LEGACY_BUNDLES_DEFAULT);
@@ -96,28 +96,29 @@ public class LoginAdminAllowList {
     }
 
     public boolean allowLoginAdministrative(Bundle b) {
-        // create local copy of ConfigurationState to avoid reading mixed configurations during an configure
+        // create local copy of ConfigurationState to avoid reading mixed configurations during an
+        // configure
         final ConfigurationState localConfig = this.config;
         if (localConfig == null) {
             throw new IllegalStateException("LoginAdminAllowList has no configuration.");
         }
 
-        if(localConfig.bypassAllowList) {
+        if (localConfig.bypassAllowList) {
             LOG.debug("Allow list is bypassed, all bundles allowed to use loginAdministrative");
             return true;
         }
 
         final String bsn = b.getSymbolicName();
 
-        if(localConfig.allowListRegexp != null && localConfig.allowListRegexp.matcher(bsn).matches()) {
+        if (localConfig.allowListRegexp != null
+                && localConfig.allowListRegexp.matcher(bsn).matches()) {
             LOG.debug("{} is allow listed to use loginAdministrative, by regexp", bsn);
             return true;
         }
 
         for (final AllowListFragment fragment : allowListFragments) {
             if (fragment.allows(bsn)) {
-                LOG.debug("{} is allow listed to use loginAdministrative, by allow list fragment '{}'",
-                        bsn, fragment);
+                LOG.debug("{} is allow listed to use loginAdministrative, by allow list fragment '{}'", bsn, fragment);
                 return true;
             }
         }
@@ -138,10 +139,17 @@ public class LoginAdminAllowList {
             Boolean legacyBypass = null;
             final Object legacyBypassObject = properties.get(LEGACY_BYPASS_PROPERTY);
             if (legacyBypassObject != null) {
-                LOG.warn("Using deprecated configuration property '{}' from configuration '{}'. " +
-                    "Update your configuration to use configuration '{}' and property '{}' instead.", 
-                    LEGACY_BYPASS_PROPERTY, LEGACY_PID, PID, "allowlist.bypass");
-                legacyBypass = Converters.standardConverter().convert(legacyBypassObject).defaultValue(false).to(Boolean.class);
+                LOG.warn(
+                        "Using deprecated configuration property '{}' from configuration '{}'. "
+                                + "Update your configuration to use configuration '{}' and property '{}' instead.",
+                        LEGACY_BYPASS_PROPERTY,
+                        LEGACY_PID,
+                        PID,
+                        "allowlist.bypass");
+                legacyBypass = Converters.standardConverter()
+                        .convert(legacyBypassObject)
+                        .defaultValue(false)
+                        .to(Boolean.class);
             }
 
             // new config takes precedence over legacy
@@ -149,9 +157,12 @@ public class LoginAdminAllowList {
             final Object newBypassObject = properties.get("allowlist.bypass");
             if (newBypassObject != null) {
                 if (legacyBypass != null) {
-                    LOG.warn("Both deprecated configuration property '{}' and non-deprecated configuration property '{}' are set. " +
-                        "The deprecated property '{}' is ignored.", 
-                        LEGACY_BYPASS_PROPERTY, "allowlist.bypass", LEGACY_BYPASS_PROPERTY);
+                    LOG.warn(
+                            "Both deprecated configuration property '{}' and non-deprecated configuration"
+                                    + " property '{}' are set. The deprecated property '{}' is ignored.",
+                            LEGACY_BYPASS_PROPERTY,
+                            "allowlist.bypass",
+                            LEGACY_BYPASS_PROPERTY);
                 }
                 bypass = config.allowlist_bypass();
             } else {
@@ -160,47 +171,59 @@ public class LoginAdminAllowList {
             String legacyRegexp = null;
             final Object legacyBundlesObject = properties.get(LEGACY_BUNDLES_PROPERTY);
             if (legacyBundlesObject != null) {
-                LOG.warn("Using deprecated configuration property '{}' from configuration '{}'. " +
-                    "Update your configuration to use configuration '{}' and property '{}' instead.", 
-                    LEGACY_BUNDLES_PROPERTY, LEGACY_PID, PID, "allowlist.bundles.regexp");
-                legacyRegexp = Converters.standardConverter().convert(legacyBundlesObject).to(String.class);
+                LOG.warn(
+                        "Using deprecated configuration property '{}' from configuration '{}'. "
+                                + "Update your configuration to use configuration '{}' and property '{}' instead.",
+                        LEGACY_BUNDLES_PROPERTY,
+                        LEGACY_PID,
+                        PID,
+                        "allowlist.bundles.regexp");
+                legacyRegexp = Converters.standardConverter()
+                        .convert(legacyBundlesObject)
+                        .to(String.class);
             }
 
             final String regexp = config.allowlist_bundles_regexp();
             if (regexp.trim().length() > 0) {
                 if (legacyRegexp != null) {
-                    LOG.warn("Both deprecated configuration property '{}' and non-deprecated configuration property '{}' are set. " +
-                        "The deprecated property '{}' is ignored.", 
-                        LEGACY_BUNDLES_PROPERTY, "allowlist.bundles.regexp", LEGACY_BUNDLES_PROPERTY);
+                    LOG.warn(
+                            "Both deprecated configuration property '{}' and non-deprecated configuration"
+                                    + " property '{}' are set. The deprecated property '{}' is ignored.",
+                            LEGACY_BUNDLES_PROPERTY,
+                            "allowlist.bundles.regexp",
+                            LEGACY_BUNDLES_PROPERTY);
                 }
                 this.allowListRegexp = Pattern.compile(regexp);
             } else {
                 this.allowListRegexp = legacyRegexp != null ? Pattern.compile(legacyRegexp) : null;
             }
             if (this.allowListRegexp != null) {
-                LOG.warn("A 'allowlist.bundles.regexp' is configured, this is NOT RECOMMENDED for production: {}", allowListRegexp);
+                LOG.warn(
+                        "A 'allowlist.bundles.regexp' is configured, this is NOT RECOMMENDED for production:" + " {}",
+                        allowListRegexp);
             }
             this.bypassAllowList = bypass;
             if (this.bypassAllowList) {
                 LOG.info("allowlist.bypass=true, allowed BSNs=<ALL>");
-                LOG.warn("All bundles are allowed to use loginAdministrative due to the 'allowlist.bypass' " +
-                        "configuration of this service. This is NOT RECOMMENDED, for security reasons."
-                );
+                LOG.warn("All bundles are allowed to use loginAdministrative due to the 'allowlist.bypass' "
+                        + "configuration of this service. This is NOT RECOMMENDED, for security reasons.");
             }
         }
     }
 
     private void ensureBackwardsCompatibility(final Map<String, Object> properties, final String propertyName) {
         final AllowListFragment oldFragment = backwardsCompatibleFragments.remove(propertyName);
-        
-        final String[] bsns = Converters.standardConverter().convert(properties.get(propertyName)).to(String[].class);        
+
+        final String[] bsns = Converters.standardConverter()
+                .convert(properties.get(propertyName))
+                .to(String[].class);
         if (bsns != null && bsns.length != 0) {
             LOG.warn("Using deprecated configuration property '{}'", propertyName);
             final AllowListFragment fragment = new AllowListFragment("deprecated-" + propertyName, bsns);
             bindAllowListFragment(fragment);
             backwardsCompatibleFragments.put(propertyName, fragment);
         }
-        
+
         if (oldFragment != null) {
             unbindAllowListFragment(oldFragment);
         }

--- a/src/main/java/org/apache/sling/jcr/base/internal/LoginAdminAllowListConfiguration.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/LoginAdminAllowListConfiguration.java
@@ -22,43 +22,37 @@ import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 @ObjectClassDefinition(
-    pid = LoginAdminAllowList.PID,
-    name = "Apache Sling Login Admin Allowlist",
-    description = "Defines which bundles can use SlingRepository.loginAdministrative()"
-)
+        pid = LoginAdminAllowList.PID,
+        name = "Apache Sling Login Admin Allowlist",
+        description = "Defines which bundles can use SlingRepository.loginAdministrative()")
 @interface LoginAdminAllowListConfiguration {
 
     /**
-     * Need to allow for bypassing the allowlist, for backwards
-     * compatibility with previous Sling versions which didn't
-     * implement it. Setting this to true is not recommended
-     * and logged as a warning.
+     * Need to allow for bypassing the allowlist, for backwards compatibility with previous Sling
+     * versions which didn't implement it. Setting this to true is not recommended and logged as a
+     * warning.
      */
     @AttributeDefinition(
-        name = "Bypass the allowlist",
-        description = "Allow all bundles to use loginAdministrative(). Should ONLY be used " +
-                      "for backwards compatibility reasons and if you are aware of " +
-                      "the related security risks."
-    )
+            name = "Bypass the allowlist",
+            description = "Allow all bundles to use loginAdministrative(). Should ONLY be used "
+                    + "for backwards compatibility reasons and if you are aware of "
+                    + "the related security risks.")
     boolean allowlist_bypass() default false;
 
     /**
-     * Regular expression for bundle symbolic names for which loginAdministrative()
-     * is allowed. NOT recommended for production use, but useful for testing with
-     * generated bundles.
-     * <br>
-     * Note that this property is hidden in order not to advertise its presence,
-     * because it is intended only for testing purposes. Specifically for use-cases
-     * like Pax-Exam, where bundles are generated on the fly and the bundle symbolic
-     * name cannot be predicted, but follows a predictable pattern.
+     * Regular expression for bundle symbolic names for which loginAdministrative() is allowed. NOT
+     * recommended for production use, but useful for testing with generated bundles. <br>
+     * Note that this property is hidden in order not to advertise its presence, because it is
+     * intended only for testing purposes. Specifically for use-cases like Pax-Exam, where bundles are
+     * generated on the fly and the bundle symbolic name cannot be predicted, but follows a
+     * predictable pattern.
      *
      * @return The configured regular exression.
      */
     @AttributeDefinition(
             name = "Allowlist regexp",
-            description = "Regular expression for bundle symbolic names for which loginAdministrative() " +
-                    "is allowed. NOT recommended for production use, but useful for testing with " +
-                    "generated bundles."
-    )
+            description = "Regular expression for bundle symbolic names for which loginAdministrative() "
+                    + "is allowed. NOT recommended for production use, but useful for testing with "
+                    + "generated bundles.")
     String allowlist_bundles_regexp() default "";
 }

--- a/src/main/java/org/apache/sling/jcr/base/internal/RepositoryPrinter.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/RepositoryPrinter.java
@@ -18,17 +18,15 @@
  */
 package org.apache.sling.jcr.base.internal;
 
+import javax.jcr.Repository;
+
 import java.io.PrintWriter;
 import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.Map;
 
-import javax.jcr.Repository;
-
-/**
- * The Printer Plugin
- */
+/** The Printer Plugin */
 public class RepositoryPrinter {
 
     private final Repository repository;
@@ -37,9 +35,9 @@ public class RepositoryPrinter {
 
     public RepositoryPrinter(final Repository repo, final Map<String, Object> props) {
         this.repository = repo;
-        if ( repo.getDescriptor(Repository.REP_NAME_DESC) != null ) {
+        if (repo.getDescriptor(Repository.REP_NAME_DESC) != null) {
             name = "Repository " + repo.getDescriptor(Repository.REP_NAME_DESC);
-        } else  if ( props.get("name") != null ) {
+        } else if (props.get("name") != null) {
             name = "Repository " + props.get("name").toString();
         } else {
             this.name = "Repository @" + repo.hashCode();
@@ -79,7 +77,7 @@ public class RepositoryPrinter {
     private void writeEntry(final PrintWriter pw, final String key, final String value) {
         pw.print(key);
         pw.print(": ");
-        if ( value != null ) {
+        if (value != null) {
             pw.println(value);
         } else {
             pw.println("-");

--- a/src/main/java/org/apache/sling/jcr/base/internal/RepositoryPrinterProvider.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/RepositoryPrinterProvider.java
@@ -18,12 +18,12 @@
  */
 package org.apache.sling.jcr.base.internal;
 
+import javax.jcr.Repository;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.jcr.Repository;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
@@ -36,15 +36,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The repository provider listens for javax.jcr.Repository services and
- * registers a web console plugin
+ * The repository provider listens for javax.jcr.Repository services and registers a web console
+ * plugin
  */
 @Component(
         property = {
-                Constants.SERVICE_DESCRIPTION + "=Apache Sling Repository Printer",
-                Constants.SERVICE_VENDOR + "=The Apache Software Foundation"
-        }
-)
+            Constants.SERVICE_DESCRIPTION + "=Apache Sling Repository Printer",
+            Constants.SERVICE_VENDOR + "=The Apache Software Foundation"
+        })
 public class RepositoryPrinterProvider {
 
     /** The logger. */
@@ -57,80 +56,69 @@ public class RepositoryPrinterProvider {
     /** List of services which are bound before activate is called. */
     private final List<PendingService> pendingServices = new ArrayList<PendingService>();
 
-    /**
-     * Activate this component.
-     */
+    /** Activate this component. */
     protected void activate(final BundleContext ctx) {
         final List<PendingService> copyList;
-        synchronized ( pendingServices ) {
+        synchronized (pendingServices) {
             this.bundleContext = ctx;
             copyList = new ArrayList<PendingService>(this.pendingServices);
             this.pendingServices.clear();
         }
-        for(final PendingService reg : copyList) {
+        for (final PendingService reg : copyList) {
             this.registerPrinter(this.bundleContext, reg.repository, reg.properties);
         }
     }
 
-    /**
-     * Deactivate this component.
-     */
+    /** Deactivate this component. */
     protected void deactivate() {
-        synchronized ( pendingServices ) {
+        synchronized (pendingServices) {
             this.bundleContext = null;
         }
     }
 
-    private void registerPrinter(final BundleContext processContext,
-            final Repository repo,
-            final Map<String, Object> props) {
+    private void registerPrinter(
+            final BundleContext processContext, final Repository repo, final Map<String, Object> props) {
         logger.info("Providing new configuration printer for {} : {}", repo, props);
-        final Long key = (Long)props.get(Constants.SERVICE_ID);
+        final Long key = (Long) props.get(Constants.SERVICE_ID);
         final RepositoryPrinter printer = new RepositoryPrinter(repo, props);
-        final ServiceRegistration<RepositoryPrinter> reg = processContext.registerService(RepositoryPrinter.class,
-                printer, printer.getProperties());
-        synchronized ( this.registrations ) {
+        final ServiceRegistration<RepositoryPrinter> reg =
+                processContext.registerService(RepositoryPrinter.class, printer, printer.getProperties());
+        synchronized (this.registrations) {
             this.registrations.put(key, reg);
         }
     }
 
-    /**
-     * Bind a new repository.
-     */
-    @Reference(policy=ReferencePolicy.DYNAMIC, cardinality=ReferenceCardinality.MULTIPLE)
+    /** Bind a new repository. */
+    @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MULTIPLE)
     protected void bindRepository(final Repository repo, final Map<String, Object> props) {
         final BundleContext processContext;
-        synchronized ( pendingServices ) {
+        synchronized (pendingServices) {
             processContext = this.bundleContext;
-            if ( processContext == null ) {
+            if (processContext == null) {
                 this.pendingServices.add(new PendingService(repo, props));
             }
         }
-        if ( processContext != null ) {
+        if (processContext != null) {
             this.registerPrinter(processContext, repo, props);
         }
     }
 
-    /**
-     * Unind a new repository.
-     */
+    /** Unind a new repository. */
     protected void unbindRepository(final Repository repo, final Map<String, Object> props) {
-        synchronized ( pendingServices ) {
+        synchronized (pendingServices) {
             this.pendingServices.remove(new PendingService(repo, props));
         }
-        final Long key = (Long)props.get(Constants.SERVICE_ID);
+        final Long key = (Long) props.get(Constants.SERVICE_ID);
         final ServiceRegistration<RepositoryPrinter> reg;
-        synchronized ( this.registrations ) {
+        synchronized (this.registrations) {
             reg = this.registrations.remove(key);
         }
-        if ( reg != null ) {
+        if (reg != null) {
             reg.unregister();
         }
     }
 
-    /**
-     * Data class for a pending service.
-     */
+    /** Data class for a pending service. */
     private static final class PendingService {
         public final Repository repository;
         public final Map<String, Object> properties;
@@ -150,13 +138,13 @@ public class RepositoryPrinterProvider {
 
         @Override
         public boolean equals(Object obj) {
-            if ( this == obj ) {
+            if (this == obj) {
                 return true;
             }
-            if ( ! (obj instanceof PendingService ) ) {
+            if (!(obj instanceof PendingService)) {
                 return false;
             }
-            return this.key == ((PendingService)obj).key;
+            return this.key == ((PendingService) obj).key;
         }
     }
 }

--- a/src/main/java/org/apache/sling/jcr/base/internal/loader/Loader.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/loader/Loader.java
@@ -18,6 +18,10 @@
  */
 package org.apache.sling.jcr.base.internal.loader;
 
+import javax.jcr.NamespaceException;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -29,10 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 
-import javax.jcr.NamespaceException;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-
 import org.apache.sling.jcr.api.SlingRepository;
 import org.apache.sling.jcr.base.NodeTypeLoader;
 import org.osgi.framework.Bundle;
@@ -43,10 +43,7 @@ import org.osgi.framework.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
-/**
- * The <code>Loader</code> TODO
- */
+/** The <code>Loader</code> TODO */
 public class Loader implements BundleListener {
 
     public static final String NODETYPES_BUNDLE_HEADER = "Sling-Nodetypes";
@@ -75,7 +72,6 @@ public class Loader implements BundleListener {
                 registerBundle(bundle);
             }
         }
-
     }
 
     public void dispose() {
@@ -98,11 +94,11 @@ public class Loader implements BundleListener {
         return sb.toString();
     }
 
-    //---------- NamespaceMapper interface
+    // ---------- NamespaceMapper interface
 
     private void defineNamespacePrefixes(final Bundle bundle, final Session session, final List<NamespaceEntry> entries)
-    throws RepositoryException {
-        for(final NamespaceEntry entry : entries) {
+            throws RepositoryException {
+        for (final NamespaceEntry entry : entries) {
 
             // the namespace prefixing is a little bit tricky:
             String mappedPrefix = null;
@@ -113,12 +109,14 @@ public class Loader implements BundleListener {
                 try {
                     session.getWorkspace().getNamespaceRegistry().registerNamespace(entry.prefix, entry.namespace);
                 } catch (final NamespaceException ne2) {
-                    logger.warn("Unable to register namespace {}:{} from bundle {} : {}",
-                            new Object[] {entry.prefix, entry.namespace, entry.prefix, getBundleIdentifier(bundle), ne2.getMessage()});
+                    logger.warn("Unable to register namespace {}:{} from bundle {} : {}", new Object[] {
+                        entry.prefix, entry.namespace, entry.prefix, getBundleIdentifier(bundle), ne2.getMessage()
+                    });
                 }
             }
-            if ( mappedPrefix != null && !mappedPrefix.equals(entry.prefix ) ) {
-                logger.warn("Namespace for {} is already registered with prefix {}. Ignoring prefix {} from bundle {}",
+            if (mappedPrefix != null && !mappedPrefix.equals(entry.prefix)) {
+                logger.warn(
+                        "Namespace for {} is already registered with prefix {}. Ignoring prefix {} from bundle" + " {}",
                         new Object[] {entry.namespace, mappedPrefix, entry.prefix, getBundleIdentifier(bundle)});
             }
         }
@@ -127,12 +125,11 @@ public class Loader implements BundleListener {
     // ---------- BundleListener ------------------------------------
 
     /**
-     * Loads and unloads any components provided by the bundle whose state
-     * changed. If the bundle has been started, the components are loaded. If
-     * the bundle is about to stop, the components are unloaded.
+     * Loads and unloads any components provided by the bundle whose state changed. If the bundle has
+     * been started, the components are loaded. If the bundle is about to stop, the components are
+     * unloaded.
      *
-     * @param event The <code>BundleEvent</code> representing the bundle state
-     *            change.
+     * @param event The <code>BundleEvent</code> representing the bundle state change.
      */
     @Override
     public final void bundleChanged(BundleEvent event) {
@@ -152,14 +149,16 @@ public class Loader implements BundleListener {
         }
     }
 
-    //---------- internal
+    // ---------- internal
 
     private void registerBundle(Bundle bundle) {
         if (this.registerBundleInternal(bundle, false)) {
             // handle delayed bundles, might help now
             int currentSize = -1;
-            for (int i=this.delayedBundles.size(); i > 0 && currentSize != this.delayedBundles.size() && !this.delayedBundles.isEmpty(); i--) {
-                for (Iterator<Bundle> di=this.delayedBundles.iterator(); di.hasNext(); ) {
+            for (int i = this.delayedBundles.size();
+                    i > 0 && currentSize != this.delayedBundles.size() && !this.delayedBundles.isEmpty();
+                    i--) {
+                for (Iterator<Bundle> di = this.delayedBundles.iterator(); di.hasNext(); ) {
                     Bundle delayed = di.next();
                     if (this.registerBundleInternal(delayed, true)) {
                         di.remove();
@@ -187,29 +186,32 @@ public class Loader implements BundleListener {
 
     /**
      * Register namespaces defined in the bundle in the namespace table.
+     *
      * @param bundle The bundle.
      */
     private void registerNamespaces(final Bundle bundle) throws RepositoryException {
         final String definition = bundle.getHeaders().get(NAMESPACES_BUNDLE_HEADER);
-        if ( definition != null ) {
-            logger.debug("registerNamespaces: Bundle {} tries to register: {}",
-                    getBundleIdentifier(bundle), definition);
+        if (definition != null) {
+            logger.debug(
+                    "registerNamespaces: Bundle {} tries to register: {}", getBundleIdentifier(bundle), definition);
             final StringTokenizer st = new StringTokenizer(definition, ",");
-            final List<NamespaceEntry>entries = new ArrayList<NamespaceEntry>();
+            final List<NamespaceEntry> entries = new ArrayList<NamespaceEntry>();
 
-            while ( st.hasMoreTokens() ) {
+            while (st.hasMoreTokens()) {
                 final String token = st.nextToken().trim();
                 int pos = token.indexOf('=');
-                if ( pos == -1 ) {
-                    logger.warn("registerNamespaces: Bundle {} has an invalid namespace manifest header entry: {}",
-                            getBundleIdentifier(bundle), token);
+                if (pos == -1) {
+                    logger.warn(
+                            "registerNamespaces: Bundle {} has an invalid namespace manifest header entry: {}",
+                            getBundleIdentifier(bundle),
+                            token);
                 } else {
                     final String prefix = token.substring(0, pos).trim();
-                    final String namespace = token.substring(pos+1).trim();
+                    final String namespace = token.substring(pos + 1).trim();
                     entries.add(new NamespaceEntry(prefix, namespace));
                 }
             }
-            if ( entries.size() > 0 ) {
+            if (entries.size() > 0) {
                 final Session session = this.getSession();
                 try {
                     this.defineNamespacePrefixes(bundle, session, entries);
@@ -220,19 +222,18 @@ public class Loader implements BundleListener {
         }
     }
 
-    private boolean registerBundleInternal (Bundle bundle, boolean isRetry) {
+    private boolean registerBundleInternal(Bundle bundle, boolean isRetry) {
         try {
             this.registerNamespaces(bundle);
             if (this.registerNodeTypes(bundle, isRetry)) {
                 return true;
             }
         } catch (RepositoryException re) {
-            if ( isRetry ) {
-                logger.error("Cannot register node types for bundle {}: {}",
-                    getBundleIdentifier(bundle), re);
+            if (isRetry) {
+                logger.error("Cannot register node types for bundle {}: {}", getBundleIdentifier(bundle), re);
             } else {
-                logger.debug("Retrying to register node types failed for bundle {}: {}",
-                        getBundleIdentifier(bundle), re);
+                logger.debug(
+                        "Retrying to register node types failed for bundle {}: {}", getBundleIdentifier(bundle), re);
             }
         }
 
@@ -244,8 +245,7 @@ public class Loader implements BundleListener {
         String typesHeader = bundle.getHeaders().get(NODETYPES_BUNDLE_HEADER);
         if (typesHeader == null) {
             // no node types in the bundle, return with success
-            logger.debug("registerNodeTypes: Bundle {} has no nodetypes",
-                getBundleIdentifier(bundle));
+            logger.debug("registerNodeTypes: Bundle {} has no nodetypes", getBundleIdentifier(bundle));
             return true;
         }
 
@@ -255,7 +255,7 @@ public class Loader implements BundleListener {
             StringTokenizer tokener = new StringTokenizer(typesHeader, ",");
             while (tokener.hasMoreTokens()) {
                 String nodeTypeFile = tokener.nextToken().trim();
-                Map<String,String> nodeTypeFileParams = new HashMap<String,String>();
+                Map<String, String> nodeTypeFileParams = new HashMap<String, String>();
                 nodeTypeFileParams.put("reregister", "true");
 
                 if (nodeTypeFile.contains(";")) {
@@ -264,14 +264,16 @@ public class Loader implements BundleListener {
                     String[] params = nodeTypeFileParam.split(":=");
                     nodeTypeFileParams.put(params[0], params[1]);
                     nodeTypeFile = nodeTypeFile.substring(0, idx);
-
                 }
 
                 URL mappingURL = bundle.getEntry(nodeTypeFile);
                 if (mappingURL == null) {
                     // if we are retrying we already logged this message once, so we won't log it again
-                    if ( !isRetry ) {
-                        logger.warn("Custom node type definition {} not found in bundle {}", nodeTypeFile, getBundleIdentifier(bundle));
+                    if (!isRetry) {
+                        logger.warn(
+                                "Custom node type definition {} not found in bundle {}",
+                                nodeTypeFile,
+                                getBundleIdentifier(bundle));
                     }
                     continue;
                 }
@@ -282,26 +284,30 @@ public class Loader implements BundleListener {
                     ins = mappingURL.openStream();
                     String reregister = nodeTypeFileParams.get("reregister");
                     boolean reregisterBool = Boolean.valueOf(reregister);
-                    NodeTypeLoader.registerNodeType(session, mappingURL.toString(), new InputStreamReader(ins), reregisterBool);
+                    NodeTypeLoader.registerNodeType(
+                            session, mappingURL.toString(), new InputStreamReader(ins), reregisterBool);
                     // log a message if retry is successful
-                    if ( isRetry ) {
-                        logger.info("Retrying to register node types from {} in bundle {} succeeded.",
-                           new Object[]{ nodeTypeFile, getBundleIdentifier(bundle)});
+                    if (isRetry) {
+                        logger.info(
+                                "Retrying to register node types from {} in bundle {} succeeded.",
+                                new Object[] {nodeTypeFile, getBundleIdentifier(bundle)});
                     }
                 } catch (IOException ioe) {
                     success = false;
                     // if we are retrying we already logged this message once, so we won't log it again
-                    if ( !isRetry ) {
-                        logger.warn("Cannot read node types {} from bundle {}: {}",
-                            new Object[]{ nodeTypeFile, getBundleIdentifier(bundle), ioe });
+                    if (!isRetry) {
+                        logger.warn(
+                                "Cannot read node types {} from bundle {}: {}",
+                                new Object[] {nodeTypeFile, getBundleIdentifier(bundle), ioe});
                         logger.warn("Stacktrace ", ioe);
                     }
                 } catch (Exception e) {
                     success = false;
                     // if we are retrying we already logged this message once, so we won't log it again
-                    if ( !isRetry ) {
-                        logger.error("Error loading node types {} from bundle {}: {}",
-                            new Object[]{ nodeTypeFile, getBundleIdentifier(bundle), e });
+                    if (!isRetry) {
+                        logger.error(
+                                "Error loading node types {} from bundle {}: {}",
+                                new Object[] {nodeTypeFile, getBundleIdentifier(bundle), e});
                         logger.error("Stacktrace ", e);
                     }
                 } finally {

--- a/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyAccessControlManager.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyAccessControlManager.java
@@ -29,7 +29,8 @@ import javax.jcr.security.AccessControlPolicyIterator;
 import javax.jcr.security.Privilege;
 import javax.jcr.version.VersionException;
 
-public class ProxyAccessControlManager<T extends AccessControlManager> extends ProxyWrapper<T> implements AccessControlManager {
+public class ProxyAccessControlManager<T extends AccessControlManager> extends ProxyWrapper<T>
+        implements AccessControlManager {
     final T mount;
 
     public ProxyAccessControlManager(ProxySession<?> mountSession, T delegate, T mount) {
@@ -52,7 +53,8 @@ public class ProxyAccessControlManager<T extends AccessControlManager> extends P
         }
     }
 
-    public boolean hasPrivileges(String absPath, Privilege[] privileges) throws PathNotFoundException, RepositoryException {
+    public boolean hasPrivileges(String absPath, Privilege[] privileges)
+            throws PathNotFoundException, RepositoryException {
         if (mountSession.isMount(absPath)) {
             return mount.hasPrivileges(absPath, privileges);
         }
@@ -66,28 +68,33 @@ public class ProxyAccessControlManager<T extends AccessControlManager> extends P
         return delegate.getPrivileges(absPath);
     }
 
-    public AccessControlPolicy[] getPolicies(String absPath) throws PathNotFoundException, AccessDeniedException, RepositoryException {
+    public AccessControlPolicy[] getPolicies(String absPath)
+            throws PathNotFoundException, AccessDeniedException, RepositoryException {
         if (mountSession.isMount(absPath)) {
             return mount.getPolicies(absPath);
         }
         return delegate.getPolicies(absPath);
     }
 
-    public AccessControlPolicy[] getEffectivePolicies(String absPath) throws PathNotFoundException, AccessDeniedException, RepositoryException {
+    public AccessControlPolicy[] getEffectivePolicies(String absPath)
+            throws PathNotFoundException, AccessDeniedException, RepositoryException {
         if (mountSession.isMount(absPath)) {
             return mount.getEffectivePolicies(absPath);
         }
         return delegate.getEffectivePolicies(absPath);
     }
 
-    public AccessControlPolicyIterator getApplicablePolicies(String absPath) throws PathNotFoundException, AccessDeniedException, RepositoryException {
+    public AccessControlPolicyIterator getApplicablePolicies(String absPath)
+            throws PathNotFoundException, AccessDeniedException, RepositoryException {
         if (mountSession.isMount(absPath)) {
             return mount.getApplicablePolicies(absPath);
         }
         return delegate.getApplicablePolicies(absPath);
     }
 
-    public void setPolicy(String absPath, AccessControlPolicy policy) throws PathNotFoundException, AccessControlException, AccessDeniedException, LockException, VersionException, RepositoryException {
+    public void setPolicy(String absPath, AccessControlPolicy policy)
+            throws PathNotFoundException, AccessControlException, AccessDeniedException, LockException,
+                    VersionException, RepositoryException {
         if (mountSession.isMountParent(absPath) || mountSession.isMount(absPath)) {
             mount.setPolicy(absPath, policy);
         }
@@ -96,7 +103,9 @@ public class ProxyAccessControlManager<T extends AccessControlManager> extends P
         }
     }
 
-    public void removePolicy(String absPath, AccessControlPolicy policy) throws PathNotFoundException, AccessControlException, AccessDeniedException, LockException, VersionException, RepositoryException {
+    public void removePolicy(String absPath, AccessControlPolicy policy)
+            throws PathNotFoundException, AccessControlException, AccessDeniedException, LockException,
+                    VersionException, RepositoryException {
         if (mountSession.isMountParent(absPath) || mountSession.isMount(absPath)) {
             mount.removePolicy(absPath, policy);
         }

--- a/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyItem.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyItem.java
@@ -119,7 +119,10 @@ public class ProxyItem<T extends Item> extends ProxyWrapper<T> implements Item {
     }
 
     @Override
-    public void save() throws AccessDeniedException, ItemExistsException, ConstraintViolationException, InvalidItemStateException, ReferentialIntegrityException, VersionException, LockException, NoSuchNodeTypeException, RepositoryException {
+    public void save()
+            throws AccessDeniedException, ItemExistsException, ConstraintViolationException, InvalidItemStateException,
+                    ReferentialIntegrityException, VersionException, LockException, NoSuchNodeTypeException,
+                    RepositoryException {
         this.mountSession.save();
     }
 
@@ -129,7 +132,9 @@ public class ProxyItem<T extends Item> extends ProxyWrapper<T> implements Item {
     }
 
     @Override
-    public void remove() throws VersionException, LockException, ConstraintViolationException, AccessDeniedException, RepositoryException {
+    public void remove()
+            throws VersionException, LockException, ConstraintViolationException, AccessDeniedException,
+                    RepositoryException {
         this.mountSession.removeItem(this.getPath());
     }
 }

--- a/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyJackrabbitAccessControlManager.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyJackrabbitAccessControlManager.java
@@ -18,12 +18,6 @@
  */
 package org.apache.sling.jcr.base.internal.mount;
 
-import java.security.Principal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-
 import javax.jcr.AccessDeniedException;
 import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
@@ -32,43 +26,61 @@ import javax.jcr.security.AccessControlException;
 import javax.jcr.security.AccessControlPolicy;
 import javax.jcr.security.Privilege;
 
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlManager;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlPolicy;
 
-public class ProxyJackrabbitAccessControlManager extends ProxyAccessControlManager<JackrabbitAccessControlManager> implements JackrabbitAccessControlManager {
-    public ProxyJackrabbitAccessControlManager(ProxySession<?> mountSession, JackrabbitAccessControlManager delegate, JackrabbitAccessControlManager mount) {
+public class ProxyJackrabbitAccessControlManager extends ProxyAccessControlManager<JackrabbitAccessControlManager>
+        implements JackrabbitAccessControlManager {
+    public ProxyJackrabbitAccessControlManager(
+            ProxySession<?> mountSession,
+            JackrabbitAccessControlManager delegate,
+            JackrabbitAccessControlManager mount) {
         super(mountSession, delegate, mount);
     }
 
-    public JackrabbitAccessControlPolicy[] getApplicablePolicies(Principal principal) throws AccessDeniedException, AccessControlException, UnsupportedRepositoryOperationException, RepositoryException {
+    public JackrabbitAccessControlPolicy[] getApplicablePolicies(Principal principal)
+            throws AccessDeniedException, AccessControlException, UnsupportedRepositoryOperationException,
+                    RepositoryException {
         List<JackrabbitAccessControlPolicy> result = new ArrayList<>();
         result.addAll(Arrays.asList(delegate.getApplicablePolicies(principal)));
         result.addAll(Arrays.asList(mount.getApplicablePolicies(principal)));
         return result.toArray(new JackrabbitAccessControlPolicy[0]);
     }
 
-    public JackrabbitAccessControlPolicy[] getPolicies(Principal principal) throws AccessDeniedException, AccessControlException, UnsupportedRepositoryOperationException, RepositoryException {
+    public JackrabbitAccessControlPolicy[] getPolicies(Principal principal)
+            throws AccessDeniedException, AccessControlException, UnsupportedRepositoryOperationException,
+                    RepositoryException {
         List<JackrabbitAccessControlPolicy> result = new ArrayList<>();
         result.addAll(Arrays.asList(delegate.getPolicies(principal)));
         result.addAll(Arrays.asList(mount.getPolicies(principal)));
         return result.toArray(new JackrabbitAccessControlPolicy[0]);
     }
 
-    public AccessControlPolicy[] getEffectivePolicies(Set<Principal> principals) throws AccessDeniedException, AccessControlException, UnsupportedRepositoryOperationException, RepositoryException {
+    public AccessControlPolicy[] getEffectivePolicies(Set<Principal> principals)
+            throws AccessDeniedException, AccessControlException, UnsupportedRepositoryOperationException,
+                    RepositoryException {
         List<AccessControlPolicy> result = new ArrayList<>();
         result.addAll(Arrays.asList(delegate.getEffectivePolicies(principals)));
         result.addAll(Arrays.asList(mount.getEffectivePolicies(principals)));
         return result.toArray(new AccessControlPolicy[0]);
     }
 
-    public boolean hasPrivileges(String absPath, Set<Principal> principals, Privilege[] privileges) throws PathNotFoundException, AccessDeniedException, RepositoryException {
+    public boolean hasPrivileges(String absPath, Set<Principal> principals, Privilege[] privileges)
+            throws PathNotFoundException, AccessDeniedException, RepositoryException {
         if (mountSession.isMount(absPath)) {
             return mount.hasPrivileges(absPath, principals, privileges);
         }
         return delegate.hasPrivileges(absPath, principals, privileges);
     }
 
-    public Privilege[] getPrivileges(String absPath, Set<Principal> principals) throws PathNotFoundException, AccessDeniedException, RepositoryException {
+    public Privilege[] getPrivileges(String absPath, Set<Principal> principals)
+            throws PathNotFoundException, AccessDeniedException, RepositoryException {
         if (mountSession.isMount(absPath)) {
             return mount.getPrivileges(absPath, principals);
         }

--- a/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyJackrabbitRepository.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyJackrabbitRepository.java
@@ -18,15 +18,15 @@
  */
 package org.apache.sling.jcr.base.internal.mount;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import javax.jcr.Credentials;
 import javax.jcr.LoginException;
 import javax.jcr.NoSuchWorkspaceException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.jackrabbit.api.JackrabbitRepository;
 import org.apache.jackrabbit.api.JackrabbitSession;
@@ -37,7 +37,8 @@ public class ProxyJackrabbitRepository extends ProxyRepository<JackrabbitReposit
     }
 
     @Override
-    public Session login(Credentials credentials, String workspaceName, Map<String, Object> attributes) throws LoginException, NoSuchWorkspaceException, RepositoryException {
+    public Session login(Credentials credentials, String workspaceName, Map<String, Object> attributes)
+            throws LoginException, NoSuchWorkspaceException, RepositoryException {
         Session jcrSession = jcr.login(credentials, workspaceName, attributes);
 
         if (attributes == null) {
@@ -47,13 +48,11 @@ public class ProxyJackrabbitRepository extends ProxyRepository<JackrabbitReposit
 
         Session mountSession = mount.login(credentials, workspaceName, attributes);
 
-        return jcrSession instanceof JackrabbitSession ?
-                new ProxyJackrabbitSession(this, (JackrabbitSession) jcrSession, mountSession, this.mountPoints) :
-                new ProxySession<>(this, jcrSession, mountSession, this.mountPoints);
+        return jcrSession instanceof JackrabbitSession
+                ? new ProxyJackrabbitSession(this, (JackrabbitSession) jcrSession, mountSession, this.mountPoints)
+                : new ProxySession<>(this, jcrSession, mountSession, this.mountPoints);
     }
 
     @Override
-    public void shutdown() {
-
-    }
+    public void shutdown() {}
 }

--- a/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyJackrabbitSession.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyJackrabbitSession.java
@@ -18,7 +18,6 @@
  */
 package org.apache.sling.jcr.base.internal.mount;
 
-import java.util.Set;
 import javax.jcr.AccessDeniedException;
 import javax.jcr.Item;
 import javax.jcr.Node;
@@ -28,19 +27,23 @@ import javax.jcr.Session;
 import javax.jcr.UnsupportedRepositoryOperationException;
 import javax.jcr.Workspace;
 
+import java.util.Set;
+
 import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.JackrabbitWorkspace;
 import org.apache.jackrabbit.api.security.principal.PrincipalManager;
 import org.apache.jackrabbit.api.security.user.UserManager;
 
 public class ProxyJackrabbitSession extends ProxySession<JackrabbitSession> implements JackrabbitSession {
-    public ProxyJackrabbitSession(ProxyRepository repository, JackrabbitSession jcr, Session mount, Set<String> mountPoints) {
+    public ProxyJackrabbitSession(
+            ProxyRepository repository, JackrabbitSession jcr, Session mount, Set<String> mountPoints) {
         super(repository, jcr, mount, mountPoints);
     }
 
     @Override
     public Workspace getWorkspace() {
-        return new ProxyJackrabbitWorkspace(this, (JackrabbitWorkspace) this.jcr.getWorkspace(), (JackrabbitWorkspace) this.mount.getWorkspace());
+        return new ProxyJackrabbitWorkspace(
+                this, (JackrabbitWorkspace) this.jcr.getWorkspace(), (JackrabbitWorkspace) this.mount.getWorkspace());
     }
 
     public boolean hasPermission(String absPath, String... actions) throws RepositoryException {
@@ -50,11 +53,13 @@ public class ProxyJackrabbitSession extends ProxySession<JackrabbitSession> impl
         return jcr.hasPermission(absPath, actions);
     }
 
-    public PrincipalManager getPrincipalManager() throws AccessDeniedException, UnsupportedRepositoryOperationException, RepositoryException {
+    public PrincipalManager getPrincipalManager()
+            throws AccessDeniedException, UnsupportedRepositoryOperationException, RepositoryException {
         return jcr.getPrincipalManager();
     }
 
-    public UserManager getUserManager() throws AccessDeniedException, UnsupportedRepositoryOperationException, RepositoryException {
+    public UserManager getUserManager()
+            throws AccessDeniedException, UnsupportedRepositoryOperationException, RepositoryException {
         return new ProxyUserManager(this, jcr.getUserManager(), ((JackrabbitSession) mount).getUserManager());
     }
 

--- a/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyJackrabbitWorkspace.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyJackrabbitWorkspace.java
@@ -26,17 +26,20 @@ import org.apache.jackrabbit.api.security.authorization.PrivilegeManager;
 import org.xml.sax.InputSource;
 
 public class ProxyJackrabbitWorkspace extends ProxyWorkspace<JackrabbitWorkspace> implements JackrabbitWorkspace {
-    public ProxyJackrabbitWorkspace(ProxySession mountSession, JackrabbitWorkspace delegate, JackrabbitWorkspace delegate2) {
+    public ProxyJackrabbitWorkspace(
+            ProxySession mountSession, JackrabbitWorkspace delegate, JackrabbitWorkspace delegate2) {
         super(mountSession, delegate, delegate2);
     }
 
     @Override
-    public void createWorkspace(String workspaceName, InputSource workspaceTemplate) throws AccessDeniedException, RepositoryException {
+    public void createWorkspace(String workspaceName, InputSource workspaceTemplate)
+            throws AccessDeniedException, RepositoryException {
         this.delegate.createWorkspace(workspaceName, workspaceTemplate);
     }
 
     @Override
     public PrivilegeManager getPrivilegeManager() throws RepositoryException {
-        return new ProxyPrivilegeManager(mountSession, this.delegate.getPrivilegeManager(), this.delegate2.getPrivilegeManager());
+        return new ProxyPrivilegeManager(
+                mountSession, this.delegate.getPrivilegeManager(), this.delegate2.getPrivilegeManager());
     }
 }

--- a/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyNamespaceRegistry.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyNamespaceRegistry.java
@@ -34,13 +34,17 @@ public class ProxyNamespaceRegistry implements NamespaceRegistry {
     }
 
     @Override
-    public void registerNamespace(String prefix, String uri) throws NamespaceException, UnsupportedRepositoryOperationException, AccessDeniedException, RepositoryException {
+    public void registerNamespace(String prefix, String uri)
+            throws NamespaceException, UnsupportedRepositoryOperationException, AccessDeniedException,
+                    RepositoryException {
         jcr.registerNamespace(prefix, uri);
         mount.registerNamespace(prefix, uri);
     }
 
     @Override
-    public void unregisterNamespace(String prefix) throws NamespaceException, UnsupportedRepositoryOperationException, AccessDeniedException, RepositoryException {
+    public void unregisterNamespace(String prefix)
+            throws NamespaceException, UnsupportedRepositoryOperationException, AccessDeniedException,
+                    RepositoryException {
         jcr.unregisterNamespace(prefix);
         mount.unregisterNamespace(prefix);
     }

--- a/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyNode.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyNode.java
@@ -18,10 +18,6 @@
  */
 package org.apache.sling.jcr.base.internal.mount;
 
-import java.io.InputStream;
-import java.math.BigDecimal;
-import java.util.Calendar;
-
 import javax.jcr.AccessDeniedException;
 import javax.jcr.Binary;
 import javax.jcr.InvalidItemStateException;
@@ -51,103 +47,145 @@ import javax.jcr.version.Version;
 import javax.jcr.version.VersionException;
 import javax.jcr.version.VersionHistory;
 
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.util.Calendar;
+
 public class ProxyNode extends ProxyItem<Node> implements Node {
     public ProxyNode(ProxySession mountSession, Node node) {
         super(mountSession, node);
     }
 
     @Override
-    public Node addNode(String relPath) throws ItemExistsException, PathNotFoundException, VersionException, ConstraintViolationException, LockException, RepositoryException {
+    public Node addNode(String relPath)
+            throws ItemExistsException, PathNotFoundException, VersionException, ConstraintViolationException,
+                    LockException, RepositoryException {
         return mountSession.addNode(getPath(), concat(getPath(), relPath), relPath);
     }
 
     @Override
-    public Node addNode(String relPath, String primaryNodeTypeName) throws ItemExistsException, PathNotFoundException, NoSuchNodeTypeException, LockException, VersionException, ConstraintViolationException, RepositoryException {
+    public Node addNode(String relPath, String primaryNodeTypeName)
+            throws ItemExistsException, PathNotFoundException, NoSuchNodeTypeException, LockException, VersionException,
+                    ConstraintViolationException, RepositoryException {
         return mountSession.addNode(getPath(), concat(getPath(), relPath), relPath, primaryNodeTypeName);
     }
 
     @Override
-    public void orderBefore(String srcChildRelPath, String destChildRelPath) throws UnsupportedRepositoryOperationException, VersionException, ConstraintViolationException, ItemNotFoundException, LockException, RepositoryException {
+    public void orderBefore(String srcChildRelPath, String destChildRelPath)
+            throws UnsupportedRepositoryOperationException, VersionException, ConstraintViolationException,
+                    ItemNotFoundException, LockException, RepositoryException {
         this.delegate.orderBefore(srcChildRelPath, destChildRelPath);
     }
 
     @Override
-    public Property setProperty(String name, Value value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public Property setProperty(String name, Value value)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         return this.mountSession.wrap(this.delegate.setProperty(name, value));
     }
 
     @Override
-    public Property setProperty(String name, Value value, int type) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public Property setProperty(String name, Value value, int type)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         return this.mountSession.wrap(this.delegate.setProperty(name, value, type));
     }
 
     @Override
-    public Property setProperty(String name, Value[] values) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public Property setProperty(String name, Value[] values)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         return this.mountSession.wrap(this.delegate.setProperty(name, values));
     }
 
     @Override
-    public Property setProperty(String name, Value[] values, int type) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public Property setProperty(String name, Value[] values, int type)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         return this.mountSession.wrap(this.delegate.setProperty(name, values, type));
     }
 
     @Override
-    public Property setProperty(String name, String[] values) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public Property setProperty(String name, String[] values)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         return this.mountSession.wrap(this.delegate.setProperty(name, values));
     }
 
     @Override
-    public Property setProperty(String name, String[] values, int type) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public Property setProperty(String name, String[] values, int type)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         return this.mountSession.wrap(this.delegate.setProperty(name, values, type));
     }
 
     @Override
-    public Property setProperty(String name, String value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public Property setProperty(String name, String value)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         return this.mountSession.wrap(this.delegate.setProperty(name, value));
     }
 
     @Override
-    public Property setProperty(String name, String value, int type) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public Property setProperty(String name, String value, int type)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         return this.mountSession.wrap(this.delegate.setProperty(name, value, type));
     }
 
     @Override
-    public Property setProperty(String name, InputStream value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public Property setProperty(String name, InputStream value)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         return this.mountSession.wrap(this.delegate.setProperty(name, value));
     }
 
     @Override
-    public Property setProperty(String name, Binary value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public Property setProperty(String name, Binary value)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         return this.mountSession.wrap(this.delegate.setProperty(name, value));
     }
 
     @Override
-    public Property setProperty(String name, boolean value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public Property setProperty(String name, boolean value)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         return this.mountSession.wrap(this.delegate.setProperty(name, value));
     }
 
     @Override
-    public Property setProperty(String name, double value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public Property setProperty(String name, double value)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         return this.mountSession.wrap(this.delegate.setProperty(name, value));
     }
 
     @Override
-    public Property setProperty(String name, BigDecimal value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public Property setProperty(String name, BigDecimal value)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         return this.mountSession.wrap(this.delegate.setProperty(name, value));
     }
 
     @Override
-    public Property setProperty(String name, long value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public Property setProperty(String name, long value)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         return this.mountSession.wrap(this.delegate.setProperty(name, value));
     }
 
     @Override
-    public Property setProperty(String name, Calendar value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public Property setProperty(String name, Calendar value)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         return this.mountSession.wrap(this.delegate.setProperty(name, value));
     }
 
     @Override
-    public Property setProperty(String name, Node value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public Property setProperty(String name, Node value)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         return this.mountSession.wrap(this.delegate.setProperty(name, value));
     }
 
@@ -267,17 +305,23 @@ public class ProxyNode extends ProxyItem<Node> implements Node {
     }
 
     @Override
-    public void setPrimaryType(String nodeTypeName) throws NoSuchNodeTypeException, VersionException, ConstraintViolationException, LockException, RepositoryException {
+    public void setPrimaryType(String nodeTypeName)
+            throws NoSuchNodeTypeException, VersionException, ConstraintViolationException, LockException,
+                    RepositoryException {
         this.delegate.setPrimaryType(nodeTypeName);
     }
 
     @Override
-    public void addMixin(String mixinName) throws NoSuchNodeTypeException, VersionException, ConstraintViolationException, LockException, RepositoryException {
+    public void addMixin(String mixinName)
+            throws NoSuchNodeTypeException, VersionException, ConstraintViolationException, LockException,
+                    RepositoryException {
         this.delegate.addMixin(mixinName);
     }
 
     @Override
-    public void removeMixin(String mixinName) throws NoSuchNodeTypeException, VersionException, ConstraintViolationException, LockException, RepositoryException {
+    public void removeMixin(String mixinName)
+            throws NoSuchNodeTypeException, VersionException, ConstraintViolationException, LockException,
+                    RepositoryException {
         this.delegate.removeMixin(mixinName);
     }
 
@@ -292,37 +336,50 @@ public class ProxyNode extends ProxyItem<Node> implements Node {
     }
 
     @Override
-    public Version checkin() throws VersionException, UnsupportedRepositoryOperationException, InvalidItemStateException, LockException, RepositoryException {
+    public Version checkin()
+            throws VersionException, UnsupportedRepositoryOperationException, InvalidItemStateException, LockException,
+                    RepositoryException {
         return this.delegate.checkin();
     }
 
     @Override
-    public void checkout() throws UnsupportedRepositoryOperationException, LockException, ActivityViolationException, RepositoryException {
+    public void checkout()
+            throws UnsupportedRepositoryOperationException, LockException, ActivityViolationException,
+                    RepositoryException {
         this.delegate.checkout();
     }
 
     @Override
-    public void doneMerge(Version version) throws VersionException, InvalidItemStateException, UnsupportedRepositoryOperationException, RepositoryException {
+    public void doneMerge(Version version)
+            throws VersionException, InvalidItemStateException, UnsupportedRepositoryOperationException,
+                    RepositoryException {
         this.delegate.doneMerge(version);
     }
 
     @Override
-    public void cancelMerge(Version version) throws VersionException, InvalidItemStateException, UnsupportedRepositoryOperationException, RepositoryException {
+    public void cancelMerge(Version version)
+            throws VersionException, InvalidItemStateException, UnsupportedRepositoryOperationException,
+                    RepositoryException {
         this.delegate.cancelMerge(version);
     }
 
     @Override
-    public void update(String srcWorkspace) throws NoSuchWorkspaceException, AccessDeniedException, LockException, InvalidItemStateException, RepositoryException {
+    public void update(String srcWorkspace)
+            throws NoSuchWorkspaceException, AccessDeniedException, LockException, InvalidItemStateException,
+                    RepositoryException {
         this.delegate.update(srcWorkspace);
     }
 
     @Override
-    public NodeIterator merge(String srcWorkspace, boolean bestEffort) throws NoSuchWorkspaceException, AccessDeniedException, MergeException, LockException, InvalidItemStateException, RepositoryException {
+    public NodeIterator merge(String srcWorkspace, boolean bestEffort)
+            throws NoSuchWorkspaceException, AccessDeniedException, MergeException, LockException,
+                    InvalidItemStateException, RepositoryException {
         return this.mountSession.wrap(this.delegate.merge(srcWorkspace, bestEffort));
     }
 
     @Override
-    public String getCorrespondingNodePath(String workspaceName) throws ItemNotFoundException, NoSuchWorkspaceException, AccessDeniedException, RepositoryException {
+    public String getCorrespondingNodePath(String workspaceName)
+            throws ItemNotFoundException, NoSuchWorkspaceException, AccessDeniedException, RepositoryException {
         return this.delegate.getCorrespondingNodePath(workspaceName);
     }
 
@@ -332,12 +389,14 @@ public class ProxyNode extends ProxyItem<Node> implements Node {
     }
 
     @Override
-    public void removeSharedSet() throws VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public void removeSharedSet()
+            throws VersionException, LockException, ConstraintViolationException, RepositoryException {
         this.delegate.removeSharedSet();
     }
 
     @Override
-    public void removeShare() throws VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public void removeShare()
+            throws VersionException, LockException, ConstraintViolationException, RepositoryException {
         this.delegate.removeShare();
     }
 
@@ -347,22 +406,31 @@ public class ProxyNode extends ProxyItem<Node> implements Node {
     }
 
     @Override
-    public void restore(String versionName, boolean removeExisting) throws VersionException, ItemExistsException, UnsupportedRepositoryOperationException, LockException, InvalidItemStateException, RepositoryException {
+    public void restore(String versionName, boolean removeExisting)
+            throws VersionException, ItemExistsException, UnsupportedRepositoryOperationException, LockException,
+                    InvalidItemStateException, RepositoryException {
         this.delegate.restore(versionName, removeExisting);
     }
 
     @Override
-    public void restore(Version version, boolean removeExisting) throws VersionException, ItemExistsException, InvalidItemStateException, UnsupportedRepositoryOperationException, LockException, RepositoryException {
+    public void restore(Version version, boolean removeExisting)
+            throws VersionException, ItemExistsException, InvalidItemStateException,
+                    UnsupportedRepositoryOperationException, LockException, RepositoryException {
         this.delegate.restore(version, removeExisting);
     }
 
     @Override
-    public void restore(Version version, String relPath, boolean removeExisting) throws PathNotFoundException, ItemExistsException, VersionException, ConstraintViolationException, UnsupportedRepositoryOperationException, LockException, InvalidItemStateException, RepositoryException {
+    public void restore(Version version, String relPath, boolean removeExisting)
+            throws PathNotFoundException, ItemExistsException, VersionException, ConstraintViolationException,
+                    UnsupportedRepositoryOperationException, LockException, InvalidItemStateException,
+                    RepositoryException {
         this.delegate.restore(version, relPath, removeExisting);
     }
 
     @Override
-    public void restoreByLabel(String versionLabel, boolean removeExisting) throws VersionException, ItemExistsException, UnsupportedRepositoryOperationException, LockException, InvalidItemStateException, RepositoryException {
+    public void restoreByLabel(String versionLabel, boolean removeExisting)
+            throws VersionException, ItemExistsException, UnsupportedRepositoryOperationException, LockException,
+                    InvalidItemStateException, RepositoryException {
         this.delegate.restoreByLabel(versionLabel, removeExisting);
     }
 
@@ -377,17 +445,22 @@ public class ProxyNode extends ProxyItem<Node> implements Node {
     }
 
     @Override
-    public Lock lock(boolean isDeep, boolean isSessionScoped) throws UnsupportedRepositoryOperationException, LockException, AccessDeniedException, InvalidItemStateException, RepositoryException {
+    public Lock lock(boolean isDeep, boolean isSessionScoped)
+            throws UnsupportedRepositoryOperationException, LockException, AccessDeniedException,
+                    InvalidItemStateException, RepositoryException {
         return this.mountSession.wrap(this.delegate.lock(isDeep, isSessionScoped));
     }
 
     @Override
-    public Lock getLock() throws UnsupportedRepositoryOperationException, LockException, AccessDeniedException, RepositoryException {
+    public Lock getLock()
+            throws UnsupportedRepositoryOperationException, LockException, AccessDeniedException, RepositoryException {
         return this.mountSession.wrap(this.delegate.getLock());
     }
 
     @Override
-    public void unlock() throws UnsupportedRepositoryOperationException, LockException, AccessDeniedException, InvalidItemStateException, RepositoryException {
+    public void unlock()
+            throws UnsupportedRepositoryOperationException, LockException, AccessDeniedException,
+                    InvalidItemStateException, RepositoryException {
         this.delegate.unlock();
     }
 
@@ -402,12 +475,14 @@ public class ProxyNode extends ProxyItem<Node> implements Node {
     }
 
     @Override
-    public void followLifecycleTransition(String transition) throws UnsupportedRepositoryOperationException, InvalidLifecycleTransitionException, RepositoryException {
+    public void followLifecycleTransition(String transition)
+            throws UnsupportedRepositoryOperationException, InvalidLifecycleTransitionException, RepositoryException {
         this.delegate.followLifecycleTransition(transition);
     }
 
     @Override
-    public String[] getAllowedLifecycleTransistions() throws UnsupportedRepositoryOperationException, RepositoryException {
+    public String[] getAllowedLifecycleTransistions()
+            throws UnsupportedRepositoryOperationException, RepositoryException {
         return this.delegate.getAllowedLifecycleTransistions();
     }
 }

--- a/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyNodeTypeManager.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyNodeTypeManager.java
@@ -66,45 +66,55 @@ public class ProxyNodeTypeManager implements NodeTypeManager {
     }
 
     @Override
-    public NodeTypeTemplate createNodeTypeTemplate() throws UnsupportedRepositoryOperationException, RepositoryException {
+    public NodeTypeTemplate createNodeTypeTemplate()
+            throws UnsupportedRepositoryOperationException, RepositoryException {
         return nodeTypeManager.createNodeTypeTemplate();
     }
 
     @Override
-    public NodeTypeTemplate createNodeTypeTemplate(NodeTypeDefinition ntd) throws UnsupportedRepositoryOperationException, RepositoryException {
+    public NodeTypeTemplate createNodeTypeTemplate(NodeTypeDefinition ntd)
+            throws UnsupportedRepositoryOperationException, RepositoryException {
         return nodeTypeManager.createNodeTypeTemplate(ntd);
     }
 
     @Override
-    public NodeDefinitionTemplate createNodeDefinitionTemplate() throws UnsupportedRepositoryOperationException, RepositoryException {
+    public NodeDefinitionTemplate createNodeDefinitionTemplate()
+            throws UnsupportedRepositoryOperationException, RepositoryException {
         return nodeTypeManager.createNodeDefinitionTemplate();
     }
 
     @Override
-    public PropertyDefinitionTemplate createPropertyDefinitionTemplate() throws UnsupportedRepositoryOperationException, RepositoryException {
+    public PropertyDefinitionTemplate createPropertyDefinitionTemplate()
+            throws UnsupportedRepositoryOperationException, RepositoryException {
         return nodeTypeManager.createPropertyDefinitionTemplate();
     }
 
     @Override
-    public NodeType registerNodeType(NodeTypeDefinition ntd, boolean allowUpdate) throws InvalidNodeTypeDefinitionException, NodeTypeExistsException, UnsupportedRepositoryOperationException, RepositoryException {
+    public NodeType registerNodeType(NodeTypeDefinition ntd, boolean allowUpdate)
+            throws InvalidNodeTypeDefinitionException, NodeTypeExistsException, UnsupportedRepositoryOperationException,
+                    RepositoryException {
         nodeTypeManager1.registerNodeType(ntd, allowUpdate);
         return nodeTypeManager.registerNodeType(ntd, allowUpdate);
     }
 
     @Override
-    public NodeTypeIterator registerNodeTypes(NodeTypeDefinition[] ntds, boolean allowUpdate) throws InvalidNodeTypeDefinitionException, NodeTypeExistsException, UnsupportedRepositoryOperationException, RepositoryException {
+    public NodeTypeIterator registerNodeTypes(NodeTypeDefinition[] ntds, boolean allowUpdate)
+            throws InvalidNodeTypeDefinitionException, NodeTypeExistsException, UnsupportedRepositoryOperationException,
+                    RepositoryException {
         nodeTypeManager1.registerNodeTypes(ntds, allowUpdate);
         return nodeTypeManager.registerNodeTypes(ntds, allowUpdate);
     }
 
     @Override
-    public void unregisterNodeType(String name) throws UnsupportedRepositoryOperationException, NoSuchNodeTypeException, RepositoryException {
+    public void unregisterNodeType(String name)
+            throws UnsupportedRepositoryOperationException, NoSuchNodeTypeException, RepositoryException {
         nodeTypeManager.unregisterNodeType(name);
         nodeTypeManager1.unregisterNodeType(name);
     }
 
     @Override
-    public void unregisterNodeTypes(String[] names) throws UnsupportedRepositoryOperationException, NoSuchNodeTypeException, RepositoryException {
+    public void unregisterNodeTypes(String[] names)
+            throws UnsupportedRepositoryOperationException, NoSuchNodeTypeException, RepositoryException {
         nodeTypeManager.unregisterNodeTypes(names);
         nodeTypeManager1.unregisterNodeTypes(names);
     }

--- a/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyPrivilegeManager.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyPrivilegeManager.java
@@ -18,15 +18,15 @@
  */
 package org.apache.sling.jcr.base.internal.mount;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import javax.jcr.AccessDeniedException;
 import javax.jcr.NamespaceException;
 import javax.jcr.RepositoryException;
 import javax.jcr.security.AccessControlException;
 import javax.jcr.security.Privilege;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.apache.jackrabbit.api.security.authorization.PrivilegeManager;
 
@@ -55,7 +55,8 @@ public class ProxyPrivilegeManager extends ProxyWrapper<PrivilegeManager> implem
         }
     }
 
-    public Privilege registerPrivilege(String privilegeName, boolean isAbstract, String[] declaredAggregateNames) throws AccessDeniedException, NamespaceException, RepositoryException {
+    public Privilege registerPrivilege(String privilegeName, boolean isAbstract, String[] declaredAggregateNames)
+            throws AccessDeniedException, NamespaceException, RepositoryException {
         mount.registerPrivilege(privilegeName, isAbstract, declaredAggregateNames);
         return delegate.registerPrivilege(privilegeName, isAbstract, declaredAggregateNames);
     }

--- a/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyProperty.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyProperty.java
@@ -18,10 +18,6 @@
  */
 package org.apache.sling.jcr.base.internal.mount;
 
-import java.io.InputStream;
-import java.math.BigDecimal;
-import java.util.Calendar;
-
 import javax.jcr.Binary;
 import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
@@ -34,56 +30,84 @@ import javax.jcr.nodetype.ConstraintViolationException;
 import javax.jcr.nodetype.PropertyDefinition;
 import javax.jcr.version.VersionException;
 
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.util.Calendar;
+
 public class ProxyProperty extends ProxyItem<Property> implements Property {
     public ProxyProperty(ProxySession mountSession, Property delegate) {
         super(mountSession, delegate);
     }
 
-    public void setValue(Value value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public void setValue(Value value)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         delegate.setValue(value);
     }
 
-    public void setValue(Value[] values) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public void setValue(Value[] values)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         delegate.setValue(values);
     }
 
-    public void setValue(String value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public void setValue(String value)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         delegate.setValue(value);
     }
 
-    public void setValue(String[] values) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public void setValue(String[] values)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         delegate.setValue(values);
     }
 
-    public void setValue(InputStream value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public void setValue(InputStream value)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         delegate.setValue(value);
     }
 
-    public void setValue(Binary value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public void setValue(Binary value)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         delegate.setValue(value);
     }
 
-    public void setValue(long value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public void setValue(long value)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         delegate.setValue(value);
     }
 
-    public void setValue(double value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public void setValue(double value)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         delegate.setValue(value);
     }
 
-    public void setValue(BigDecimal value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public void setValue(BigDecimal value)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         delegate.setValue(value);
     }
 
-    public void setValue(Calendar value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public void setValue(Calendar value)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         delegate.setValue(value);
     }
 
-    public void setValue(boolean value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public void setValue(boolean value)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         delegate.setValue(value);
     }
 
-    public void setValue(Node value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+    public void setValue(Node value)
+            throws ValueFormatException, VersionException, LockException, ConstraintViolationException,
+                    RepositoryException {
         delegate.setValue(value);
     }
 

--- a/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyQuery.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyQuery.java
@@ -18,10 +18,6 @@
  */
 package org.apache.sling.jcr.base.internal.mount;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
 import javax.jcr.ItemExistsException;
 import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
@@ -38,6 +34,10 @@ import javax.jcr.query.QueryResult;
 import javax.jcr.query.Row;
 import javax.jcr.query.RowIterator;
 import javax.jcr.version.VersionException;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 public class ProxyQuery extends ProxyWrapper<Query> implements Query {
     private final Query delegate2;
@@ -58,119 +58,121 @@ public class ProxyQuery extends ProxyWrapper<Query> implements Query {
         return this.mountSession.wrap(new QueryResult() {
             @Override
             public String[] getColumnNames() throws RepositoryException {
-            	return result1.getColumnNames();
+                return result1.getColumnNames();
             }
 
             @Override
             public RowIterator getRows() throws RepositoryException {
-            	final RowIterator i1 = result1.getRows();
-            	RowIterator i2 = null;
-            	if (result2 != null) {
+                final RowIterator i1 = result1.getRows();
+                RowIterator i2 = null;
+                if (result2 != null) {
                     i2 = result2.getRows();
                 }
-            	if ( i2 == null || !i2.hasNext() ) {
-            		return i1;
-            	}
-            	if ( !i1.hasNext() ) {
-            		return i2;
-            	}
+                if (i2 == null || !i2.hasNext()) {
+                    return i1;
+                }
+                if (!i1.hasNext()) {
+                    return i2;
+                }
                 final List<RowIterator> list = new ArrayList<>();
                 list.add(i1);
                 list.add(i2);
-                @SuppressWarnings({ "unchecked", "rawtypes" })
-				final Iterator<Row> iter = new ChainedIterator(list.iterator());
+                @SuppressWarnings({"unchecked", "rawtypes"})
+                final Iterator<Row> iter = new ChainedIterator(list.iterator());
                 return new RowIterator() {
-					private volatile long position = 0;
-					@Override
-					public Object next() {
-					    position++;
-					    return iter.next();
-					}
+                    private volatile long position = 0;
 
-					@Override
-					public boolean hasNext() {
-						return iter.hasNext();
-					}
+                    @Override
+                    public Object next() {
+                        position++;
+                        return iter.next();
+                    }
 
-					@Override
-					public void skip(long skipNum) {
-						while (skipNum-- > 0) {
-						    next();
-						}
-					}
+                    @Override
+                    public boolean hasNext() {
+                        return iter.hasNext();
+                    }
 
-					@Override
-					public long getSize() {
-						return -1;
-					}
+                    @Override
+                    public void skip(long skipNum) {
+                        while (skipNum-- > 0) {
+                            next();
+                        }
+                    }
 
-					@Override
-					public long getPosition() {
-						return position;
-					}
+                    @Override
+                    public long getSize() {
+                        return -1;
+                    }
 
-					@Override
-					public Row nextRow() {
-						position++;
-						return iter.next();
-					}
-				};
+                    @Override
+                    public long getPosition() {
+                        return position;
+                    }
+
+                    @Override
+                    public Row nextRow() {
+                        position++;
+                        return iter.next();
+                    }
+                };
             }
 
             @Override
             public NodeIterator getNodes() throws RepositoryException {
-            	final NodeIterator i1 = result1.getNodes();
+                final NodeIterator i1 = result1.getNodes();
                 NodeIterator i2 = null;
                 if (result2 != null) {
                     i2 = result2.getNodes();
                 }
-            	if ( i2 == null || !i2.hasNext() ) {
-            		return i1;
-            	}
-            	if ( !i1.hasNext() ) {
-            		return i2;
-            	}
+                if (i2 == null || !i2.hasNext()) {
+                    return i1;
+                }
+                if (!i1.hasNext()) {
+                    return i2;
+                }
                 final List<NodeIterator> list = new ArrayList<>();
                 list.add(i1);
                 list.add(i2);
-                @SuppressWarnings({ "unchecked", "rawtypes" })
-				final Iterator<Node> iter = new ChainedIterator(list.iterator());
+                @SuppressWarnings({"unchecked", "rawtypes"})
+                final Iterator<Node> iter = new ChainedIterator(list.iterator());
                 return new NodeIterator() {
-					private volatile long position = 0;
-					@Override
-					public Object next() {
-					    position++;
-					    return iter.next();
-					}
+                    private volatile long position = 0;
 
-					@Override
-					public boolean hasNext() {
-						return iter.hasNext();
-					}
+                    @Override
+                    public Object next() {
+                        position++;
+                        return iter.next();
+                    }
 
-					@Override
-					public void skip(long skipNum) {
-						while (skipNum-- > 0) {
-						    next();
-						}
-					}
+                    @Override
+                    public boolean hasNext() {
+                        return iter.hasNext();
+                    }
 
-					@Override
-					public long getSize() {
-						return -1;
-					}
+                    @Override
+                    public void skip(long skipNum) {
+                        while (skipNum-- > 0) {
+                            next();
+                        }
+                    }
 
-					@Override
-					public long getPosition() {
-						return position;
-					}
+                    @Override
+                    public long getSize() {
+                        return -1;
+                    }
 
-					@Override
-					public Node nextNode() {
-					    position++;
-					    return iter.next();
-					}
-				};
+                    @Override
+                    public long getPosition() {
+                        return position;
+                    }
+
+                    @Override
+                    public Node nextNode() {
+                        position++;
+                        return iter.next();
+                    }
+                };
             }
 
             @Override
@@ -206,7 +208,7 @@ public class ProxyQuery extends ProxyWrapper<Query> implements Query {
         try {
             return delegate.getStoredQueryPath();
         } catch (ItemNotFoundException ex) {
-           try {
+            try {
                 if (delegate2 != null) {
                     return delegate2.getStoredQueryPath();
                 } else {
@@ -218,8 +220,11 @@ public class ProxyQuery extends ProxyWrapper<Query> implements Query {
         }
     }
 
-    public Node storeAsNode(String absPath) throws ItemExistsException, PathNotFoundException, VersionException, ConstraintViolationException, LockException, UnsupportedRepositoryOperationException, RepositoryException {
-        return this.mountSession.wrap(this.mountSession.isMount(absPath) ? delegate2.storeAsNode(absPath) : delegate.storeAsNode(absPath));
+    public Node storeAsNode(String absPath)
+            throws ItemExistsException, PathNotFoundException, VersionException, ConstraintViolationException,
+                    LockException, UnsupportedRepositoryOperationException, RepositoryException {
+        return this.mountSession.wrap(
+                this.mountSession.isMount(absPath) ? delegate2.storeAsNode(absPath) : delegate.storeAsNode(absPath));
     }
 
     public void bindValue(String varName, Value value) throws IllegalArgumentException, RepositoryException {

--- a/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyQueryManager.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyQueryManager.java
@@ -35,7 +35,10 @@ public class ProxyQueryManager extends ProxyWrapper<QueryManager> implements Que
 
     @Override
     public Query createQuery(String statement, String language) throws InvalidQueryException, RepositoryException {
-        return new ProxyQuery(this.mountSession, delegate.createQuery(statement, language), delegate2.createQuery(statement, language));
+        return new ProxyQuery(
+                this.mountSession,
+                delegate.createQuery(statement, language),
+                delegate2.createQuery(statement, language));
     }
 
     @Override

--- a/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyQueryObjectModelFactory.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyQueryObjectModelFactory.java
@@ -55,45 +55,58 @@ import javax.jcr.query.qom.Source;
 import javax.jcr.query.qom.StaticOperand;
 import javax.jcr.query.qom.UpperCase;
 
-public class ProxyQueryObjectModelFactory extends ProxyWrapper<QueryObjectModelFactory> implements QueryObjectModelFactory {
+public class ProxyQueryObjectModelFactory extends ProxyWrapper<QueryObjectModelFactory>
+        implements QueryObjectModelFactory {
     private final QueryObjectModelFactory delegate2;
 
-    public ProxyQueryObjectModelFactory(ProxySession<?> mountSession, QueryObjectModelFactory delegate, QueryObjectModelFactory delegate2) {
+    public ProxyQueryObjectModelFactory(
+            ProxySession<?> mountSession, QueryObjectModelFactory delegate, QueryObjectModelFactory delegate2) {
         super(mountSession, delegate);
         this.delegate2 = delegate2;
     }
 
-    public QueryObjectModel createQuery(Source source, Constraint constraint, Ordering[] orderings, Column[] columns) throws InvalidQueryException, RepositoryException {
+    public QueryObjectModel createQuery(Source source, Constraint constraint, Ordering[] orderings, Column[] columns)
+            throws InvalidQueryException, RepositoryException {
         if (delegate2 != null) {
-            return new ProxyQueryObjectModel(this.mountSession, delegate.createQuery(source, constraint, orderings, columns),
+            return new ProxyQueryObjectModel(
+                    this.mountSession,
+                    delegate.createQuery(source, constraint, orderings, columns),
                     delegate2.createQuery(source, constraint, orderings, columns));
         } else {
-            return new ProxyQueryObjectModel(this.mountSession, delegate.createQuery(source, constraint, orderings, columns),
-                    null);
+            return new ProxyQueryObjectModel(
+                    this.mountSession, delegate.createQuery(source, constraint, orderings, columns), null);
         }
     }
 
-    public Selector selector(String nodeTypeName, String selectorName) throws InvalidQueryException, RepositoryException {
+    public Selector selector(String nodeTypeName, String selectorName)
+            throws InvalidQueryException, RepositoryException {
         return delegate.selector(nodeTypeName, selectorName);
     }
 
-    public Join join(Source left, Source right, String joinType, JoinCondition joinCondition) throws InvalidQueryException, RepositoryException {
+    public Join join(Source left, Source right, String joinType, JoinCondition joinCondition)
+            throws InvalidQueryException, RepositoryException {
         return delegate.join(left, right, joinType, joinCondition);
     }
 
-    public EquiJoinCondition equiJoinCondition(String selector1Name, String property1Name, String selector2Name, String property2Name) throws InvalidQueryException, RepositoryException {
+    public EquiJoinCondition equiJoinCondition(
+            String selector1Name, String property1Name, String selector2Name, String property2Name)
+            throws InvalidQueryException, RepositoryException {
         return delegate.equiJoinCondition(selector1Name, property1Name, selector2Name, property2Name);
     }
 
-    public SameNodeJoinCondition sameNodeJoinCondition(String selector1Name, String selector2Name, String selector2Path) throws InvalidQueryException, RepositoryException {
+    public SameNodeJoinCondition sameNodeJoinCondition(String selector1Name, String selector2Name, String selector2Path)
+            throws InvalidQueryException, RepositoryException {
         return delegate.sameNodeJoinCondition(selector1Name, selector2Name, selector2Path);
     }
 
-    public ChildNodeJoinCondition childNodeJoinCondition(String childSelectorName, String parentSelectorName) throws InvalidQueryException, RepositoryException {
+    public ChildNodeJoinCondition childNodeJoinCondition(String childSelectorName, String parentSelectorName)
+            throws InvalidQueryException, RepositoryException {
         return delegate.childNodeJoinCondition(childSelectorName, parentSelectorName);
     }
 
-    public DescendantNodeJoinCondition descendantNodeJoinCondition(String descendantSelectorName, String ancestorSelectorName) throws InvalidQueryException, RepositoryException {
+    public DescendantNodeJoinCondition descendantNodeJoinCondition(
+            String descendantSelectorName, String ancestorSelectorName)
+            throws InvalidQueryException, RepositoryException {
         return delegate.descendantNodeJoinCondition(descendantSelectorName, ancestorSelectorName);
     }
 
@@ -109,15 +122,19 @@ public class ProxyQueryObjectModelFactory extends ProxyWrapper<QueryObjectModelF
         return delegate.not(constraint);
     }
 
-    public Comparison comparison(DynamicOperand operand1, String operator, StaticOperand operand2) throws InvalidQueryException, RepositoryException {
+    public Comparison comparison(DynamicOperand operand1, String operator, StaticOperand operand2)
+            throws InvalidQueryException, RepositoryException {
         return delegate.comparison(operand1, operator, operand2);
     }
 
-    public PropertyExistence propertyExistence(String selectorName, String propertyName) throws InvalidQueryException, RepositoryException {
+    public PropertyExistence propertyExistence(String selectorName, String propertyName)
+            throws InvalidQueryException, RepositoryException {
         return delegate.propertyExistence(selectorName, propertyName);
     }
 
-    public FullTextSearch fullTextSearch(String selectorName, String propertyName, StaticOperand fullTextSearchExpression) throws InvalidQueryException, RepositoryException {
+    public FullTextSearch fullTextSearch(
+            String selectorName, String propertyName, StaticOperand fullTextSearchExpression)
+            throws InvalidQueryException, RepositoryException {
         return delegate.fullTextSearch(selectorName, propertyName, fullTextSearchExpression);
     }
 
@@ -129,11 +146,13 @@ public class ProxyQueryObjectModelFactory extends ProxyWrapper<QueryObjectModelF
         return delegate.childNode(selectorName, path);
     }
 
-    public DescendantNode descendantNode(String selectorName, String path) throws InvalidQueryException, RepositoryException {
+    public DescendantNode descendantNode(String selectorName, String path)
+            throws InvalidQueryException, RepositoryException {
         return delegate.descendantNode(selectorName, path);
     }
 
-    public PropertyValue propertyValue(String selectorName, String propertyName) throws InvalidQueryException, RepositoryException {
+    public PropertyValue propertyValue(String selectorName, String propertyName)
+            throws InvalidQueryException, RepositoryException {
         return delegate.propertyValue(selectorName, propertyName);
     }
 
@@ -149,7 +168,8 @@ public class ProxyQueryObjectModelFactory extends ProxyWrapper<QueryObjectModelF
         return delegate.nodeLocalName(selectorName);
     }
 
-    public FullTextSearchScore fullTextSearchScore(String selectorName) throws InvalidQueryException, RepositoryException {
+    public FullTextSearchScore fullTextSearchScore(String selectorName)
+            throws InvalidQueryException, RepositoryException {
         return delegate.fullTextSearchScore(selectorName);
     }
 
@@ -177,7 +197,8 @@ public class ProxyQueryObjectModelFactory extends ProxyWrapper<QueryObjectModelF
         return delegate.descending(operand);
     }
 
-    public Column column(String selectorName, String propertyName, String columnName) throws InvalidQueryException, RepositoryException {
+    public Column column(String selectorName, String propertyName, String columnName)
+            throws InvalidQueryException, RepositoryException {
         return delegate.column(selectorName, propertyName, columnName);
     }
 }

--- a/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyRepository.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyRepository.java
@@ -18,11 +18,6 @@
  */
 package org.apache.sling.jcr.base.internal.mount;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import javax.jcr.Credentials;
 import javax.jcr.LoginException;
 import javax.jcr.NoSuchWorkspaceException;
@@ -31,6 +26,11 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.SimpleCredentials;
 import javax.jcr.Value;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.jackrabbit.api.JackrabbitRepository;
 import org.apache.jackrabbit.api.JackrabbitSession;
@@ -46,7 +46,6 @@ public class ProxyRepository<T extends Repository> implements Repository {
         this.mount = mount;
         this.mountPoints = new HashSet<>(mountPoint);
     }
-
 
     @Override
     public String[] getDescriptorKeys() {
@@ -79,7 +78,8 @@ public class ProxyRepository<T extends Repository> implements Repository {
     }
 
     @Override
-    public Session login(Credentials credentials, String workspaceName) throws LoginException, NoSuchWorkspaceException, RepositoryException {
+    public Session login(Credentials credentials, String workspaceName)
+            throws LoginException, NoSuchWorkspaceException, RepositoryException {
         Session jcrSession = jcr.login(credentials, workspaceName);
 
         Session mountSession;
@@ -87,13 +87,12 @@ public class ProxyRepository<T extends Repository> implements Repository {
             Map<String, Object> attributes = new HashMap<>();
             attributes.put(RepositoryMount.PARENT_SESSION_KEY, jcrSession);
             mountSession = ((JackrabbitRepository) mount).login(credentials, workspaceName, attributes);
-        }
-        else {
+        } else {
             mountSession = mount.login(credentials, workspaceName);
         }
-        return jcrSession instanceof JackrabbitSession ?
-                new ProxyJackrabbitSession(this, (JackrabbitSession) jcrSession, mountSession, this.mountPoints) :
-                new ProxySession<>(this, jcrSession, mountSession, this.mountPoints);
+        return jcrSession instanceof JackrabbitSession
+                ? new ProxyJackrabbitSession(this, (JackrabbitSession) jcrSession, mountSession, this.mountPoints)
+                : new ProxySession<>(this, jcrSession, mountSession, this.mountPoints);
     }
 
     @Override
@@ -118,16 +117,25 @@ public class ProxyRepository<T extends Repository> implements Repository {
 
         Map<String, Object> attributes = new HashMap<>();
         attributes.put(RepositoryMount.PARENT_SESSION_KEY, session);
-        Session mountSession = ((JackrabbitRepository) mount).login(new SimpleCredentials(session.getUserID(), new char[0]),session.getWorkspace().getName(), attributes );
+        Session mountSession = ((JackrabbitRepository) mount)
+                .login(
+                        new SimpleCredentials(session.getUserID(), new char[0]),
+                        session.getWorkspace().getName(),
+                        attributes);
 
-        return session instanceof JackrabbitSession ?
-                new ProxyJackrabbitSession(this, (JackrabbitSession) session, mountSession, this.mountPoints) :
-                new ProxySession<>(this, session, mountSession, this.mountPoints);
+        return session instanceof JackrabbitSession
+                ? new ProxyJackrabbitSession(this, (JackrabbitSession) session, mountSession, this.mountPoints)
+                : new ProxySession<>(this, session, mountSession, this.mountPoints);
     }
 
     Session impersonate(Credentials credentials, Session jcr, Session mount) throws RepositoryException {
-        return jcr instanceof JackrabbitSession ?
-                new ProxyJackrabbitSession(this, (JackrabbitSession) jcr.impersonate(credentials), mount.impersonate(credentials), this.mountPoints) :
-                new ProxySession<>(this, jcr.impersonate(credentials), mount.impersonate(credentials), this.mountPoints);
+        return jcr instanceof JackrabbitSession
+                ? new ProxyJackrabbitSession(
+                        this,
+                        (JackrabbitSession) jcr.impersonate(credentials),
+                        mount.impersonate(credentials),
+                        this.mountPoints)
+                : new ProxySession<>(
+                        this, jcr.impersonate(credentials), mount.impersonate(credentials), this.mountPoints);
     }
 }

--- a/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxySession.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxySession.java
@@ -18,17 +18,6 @@
  */
 package org.apache.sling.jcr.base.internal.mount;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.security.AccessControlException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-
 import javax.jcr.AccessDeniedException;
 import javax.jcr.Credentials;
 import javax.jcr.InvalidItemStateException;
@@ -62,6 +51,17 @@ import javax.jcr.retention.RetentionManager;
 import javax.jcr.security.AccessControlManager;
 import javax.jcr.version.VersionException;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.AccessControlException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlManager;
 import org.apache.jackrabbit.commons.iterator.NodeIteratorAdapter;
 import org.apache.jackrabbit.oak.commons.PathUtils;
@@ -82,7 +82,9 @@ public class ProxySession<T extends Session> implements Session {
     }
 
     boolean isMount(String path) {
-        return path != null && (mountPoints.contains(path) || mountPoints.stream().anyMatch(mountPoint -> path.startsWith(mountPoint + "/")));
+        return path != null
+                && (mountPoints.contains(path)
+                        || mountPoints.stream().anyMatch(mountPoint -> path.startsWith(mountPoint + "/")));
     }
 
     boolean isMountParent(String path) {
@@ -90,19 +92,26 @@ public class ProxySession<T extends Session> implements Session {
     }
 
     boolean isMountDirectParent(String path) {
-        return mountPoints.stream().anyMatch(mountPoint -> PathUtils.getParentPath(mountPoint).equals(path));
+        return mountPoints.stream()
+                .anyMatch(mountPoint -> PathUtils.getParentPath(mountPoint).equals(path));
     }
 
     public <F> F wrap(F source) {
         if (source instanceof ProxyWrapper) {
             return source;
         }
-        return (F) (source instanceof Node ? new ProxyNode(this, (Node) source) :
-                source instanceof Property ? new ProxyProperty(this, (Property) source) :
-                        source instanceof Item ? new ProxyItem<>(this, (Item) source) :
-                                source instanceof Lock ? new ProxyLock(this, (Lock) source) :
-                                        source instanceof QueryResult ? new ProxyQueryResult(this, (QueryResult) source) :
-                                                source);
+        return (F)
+                (source instanceof Node
+                        ? new ProxyNode(this, (Node) source)
+                        : source instanceof Property
+                                ? new ProxyProperty(this, (Property) source)
+                                : source instanceof Item
+                                        ? new ProxyItem<>(this, (Item) source)
+                                        : source instanceof Lock
+                                                ? new ProxyLock(this, (Lock) source)
+                                                : source instanceof QueryResult
+                                                        ? new ProxyQueryResult(this, (QueryResult) source)
+                                                        : source);
     }
 
     public <F> F unwrap(F source) {
@@ -359,7 +368,9 @@ public class ProxySession<T extends Session> implements Session {
     }
 
     @Override
-    public void removeItem(String absPath) throws VersionException, LockException, ConstraintViolationException, AccessDeniedException, RepositoryException {
+    public void removeItem(String absPath)
+            throws VersionException, LockException, ConstraintViolationException, AccessDeniedException,
+                    RepositoryException {
         if (sync != null) {
             sync.remove(absPath);
         }
@@ -381,17 +392,23 @@ public class ProxySession<T extends Session> implements Session {
 
     private volatile Set<String> sync;
 
-    private final static List<String> ignore = Arrays.asList("jcr:primaryType", "jcr:created", "jcr:createdBy");
+    private static final List<String> ignore = Arrays.asList("jcr:primaryType", "jcr:created", "jcr:createdBy");
 
     @Override
-    public void save() throws AccessDeniedException, ItemExistsException, ReferentialIntegrityException, ConstraintViolationException, InvalidItemStateException, VersionException, LockException, NoSuchNodeTypeException, RepositoryException {
+    public void save()
+            throws AccessDeniedException, ItemExistsException, ReferentialIntegrityException,
+                    ConstraintViolationException, InvalidItemStateException, VersionException, LockException,
+                    NoSuchNodeTypeException, RepositoryException {
         if (sync != null) {
             for (String path : sync) {
                 if (this.jcr.nodeExists(path)) {
                     Node jcrNode = jcr.getNode(path);
-                    Node mountNode = mount.nodeExists(path) ?
-                            mount.getNode(path) :
-                            mount.getNode(PathUtils.getParentPath(path)).addNode(PathUtils.getName(path), jcrNode.getPrimaryNodeType().getName());
+                    Node mountNode = mount.nodeExists(path)
+                            ? mount.getNode(path)
+                            : mount.getNode(PathUtils.getParentPath(path))
+                                    .addNode(
+                                            PathUtils.getName(path),
+                                            jcrNode.getPrimaryNodeType().getName());
                     for (PropertyIterator iter = jcrNode.getProperties(); iter.hasNext(); ) {
                         Property property = iter.nextProperty();
                         try {
@@ -456,7 +473,9 @@ public class ProxySession<T extends Session> implements Session {
     }
 
     @Override
-    public ContentHandler getImportContentHandler(String parentAbsPath, int uuidBehavior) throws PathNotFoundException, ConstraintViolationException, VersionException, LockException, RepositoryException {
+    public ContentHandler getImportContentHandler(String parentAbsPath, int uuidBehavior)
+            throws PathNotFoundException, ConstraintViolationException, VersionException, LockException,
+                    RepositoryException {
         if (isMount(parentAbsPath)) {
             return this.mount.getImportContentHandler(parentAbsPath, uuidBehavior);
         } else {
@@ -465,7 +484,9 @@ public class ProxySession<T extends Session> implements Session {
     }
 
     @Override
-    public void importXML(String parentAbsPath, InputStream in, int uuidBehavior) throws IOException, PathNotFoundException, ItemExistsException, ConstraintViolationException, VersionException, InvalidSerializedDataException, LockException, RepositoryException {
+    public void importXML(String parentAbsPath, InputStream in, int uuidBehavior)
+            throws IOException, PathNotFoundException, ItemExistsException, ConstraintViolationException,
+                    VersionException, InvalidSerializedDataException, LockException, RepositoryException {
         if (isMount(parentAbsPath)) {
             this.mount.importXML(parentAbsPath, in, uuidBehavior);
         } else {
@@ -474,7 +495,8 @@ public class ProxySession<T extends Session> implements Session {
     }
 
     @Override
-    public void exportSystemView(String absPath, ContentHandler contentHandler, boolean skipBinary, boolean noRecurse) throws PathNotFoundException, SAXException, RepositoryException {
+    public void exportSystemView(String absPath, ContentHandler contentHandler, boolean skipBinary, boolean noRecurse)
+            throws PathNotFoundException, SAXException, RepositoryException {
         if (isMount(absPath)) {
             this.mount.exportSystemView(absPath, contentHandler, skipBinary, noRecurse);
         } else {
@@ -483,7 +505,8 @@ public class ProxySession<T extends Session> implements Session {
     }
 
     @Override
-    public void exportSystemView(String absPath, OutputStream out, boolean skipBinary, boolean noRecurse) throws IOException, PathNotFoundException, RepositoryException {
+    public void exportSystemView(String absPath, OutputStream out, boolean skipBinary, boolean noRecurse)
+            throws IOException, PathNotFoundException, RepositoryException {
         if (isMount(absPath)) {
             this.mount.exportSystemView(absPath, out, skipBinary, noRecurse);
         } else {
@@ -492,7 +515,8 @@ public class ProxySession<T extends Session> implements Session {
     }
 
     @Override
-    public void exportDocumentView(String absPath, ContentHandler contentHandler, boolean skipBinary, boolean noRecurse) throws PathNotFoundException, SAXException, RepositoryException {
+    public void exportDocumentView(String absPath, ContentHandler contentHandler, boolean skipBinary, boolean noRecurse)
+            throws PathNotFoundException, SAXException, RepositoryException {
         if (isMount(absPath)) {
             this.mount.exportDocumentView(absPath, contentHandler, skipBinary, noRecurse);
         } else {
@@ -501,7 +525,8 @@ public class ProxySession<T extends Session> implements Session {
     }
 
     @Override
-    public void exportDocumentView(String absPath, OutputStream out, boolean skipBinary, boolean noRecurse) throws IOException, PathNotFoundException, RepositoryException {
+    public void exportDocumentView(String absPath, OutputStream out, boolean skipBinary, boolean noRecurse)
+            throws IOException, PathNotFoundException, RepositoryException {
         if (isMount(absPath)) {
             this.mount.exportDocumentView(absPath, out, skipBinary, noRecurse);
         } else {
@@ -557,11 +582,14 @@ public class ProxySession<T extends Session> implements Session {
     }
 
     @Override
-    public AccessControlManager getAccessControlManager() throws UnsupportedRepositoryOperationException, RepositoryException {
+    public AccessControlManager getAccessControlManager()
+            throws UnsupportedRepositoryOperationException, RepositoryException {
         AccessControlManager manager = this.jcr.getAccessControlManager();
-        return manager instanceof JackrabbitAccessControlManager ?
-                new ProxyJackrabbitAccessControlManager(this, (JackrabbitAccessControlManager) manager, (JackrabbitAccessControlManager) this.mount.getAccessControlManager()) :
-                new ProxyAccessControlManager<>(this, manager, this.mount.getAccessControlManager());
+        return manager instanceof JackrabbitAccessControlManager
+                ? new ProxyJackrabbitAccessControlManager(
+                        this, (JackrabbitAccessControlManager) manager, (JackrabbitAccessControlManager)
+                                this.mount.getAccessControlManager())
+                : new ProxyAccessControlManager<>(this, manager, this.mount.getAccessControlManager());
     }
 
     @Override
@@ -570,7 +598,9 @@ public class ProxySession<T extends Session> implements Session {
     }
 
     @Override
-    public void move(String srcAbsPath, String destAbsPath) throws ItemExistsException, PathNotFoundException, VersionException, ConstraintViolationException, LockException, RepositoryException {
+    public void move(String srcAbsPath, String destAbsPath)
+            throws ItemExistsException, PathNotFoundException, VersionException, ConstraintViolationException,
+                    LockException, RepositoryException {
         if (isMount(srcAbsPath) && isMount(destAbsPath)) {
             this.mount.move(srcAbsPath, destAbsPath);
         } else if (!isMount(srcAbsPath) && !isMount(destAbsPath)) {

--- a/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyUserManager.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyUserManager.java
@@ -18,11 +18,11 @@
  */
 package org.apache.sling.jcr.base.internal.mount;
 
-import java.security.Principal;
-import java.util.Iterator;
-
 import javax.jcr.RepositoryException;
 import javax.jcr.UnsupportedRepositoryOperationException;
+
+import java.security.Principal;
+import java.util.Iterator;
 
 import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.user.Authorizable;
@@ -41,12 +41,12 @@ public class ProxyUserManager extends ProxyWrapper<UserManager> implements UserM
         this.mount = mount;
     }
 
-
     public Authorizable getAuthorizable(String id) throws RepositoryException {
         return delegate.getAuthorizable(id);
     }
 
-    public <T extends Authorizable> T getAuthorizable(String id, Class<T> authorizableClass) throws AuthorizableTypeException, RepositoryException {
+    public <T extends Authorizable> T getAuthorizable(String id, Class<T> authorizableClass)
+            throws AuthorizableTypeException, RepositoryException {
         return delegate.getAuthorizable(id, authorizableClass);
     }
 
@@ -54,7 +54,8 @@ public class ProxyUserManager extends ProxyWrapper<UserManager> implements UserM
         return delegate.getAuthorizable(principal);
     }
 
-    public Authorizable getAuthorizableByPath(String path) throws UnsupportedRepositoryOperationException, RepositoryException {
+    public Authorizable getAuthorizableByPath(String path)
+            throws UnsupportedRepositoryOperationException, RepositoryException {
         return delegate.getAuthorizableByPath(path);
     }
 
@@ -62,7 +63,8 @@ public class ProxyUserManager extends ProxyWrapper<UserManager> implements UserM
         return delegate.findAuthorizables(relPath, value);
     }
 
-    public Iterator<Authorizable> findAuthorizables(String relPath, String value, int searchType) throws RepositoryException {
+    public Iterator<Authorizable> findAuthorizables(String relPath, String value, int searchType)
+            throws RepositoryException {
         return delegate.findAuthorizables(relPath, value, searchType);
     }
 
@@ -76,13 +78,15 @@ public class ProxyUserManager extends ProxyWrapper<UserManager> implements UserM
         return user;
     }
 
-    public User createUser(String userID, String password, Principal principal, String intermediatePath) throws AuthorizableExistsException, RepositoryException {
+    public User createUser(String userID, String password, Principal principal, String intermediatePath)
+            throws AuthorizableExistsException, RepositoryException {
         User user = delegate.createUser(userID, password, principal, intermediatePath);
         mount.createUser(userID, password, principal, user.getPath());
         return user;
     }
 
-    public User createSystemUser(String userID, String intermediatePath) throws AuthorizableExistsException, RepositoryException {
+    public User createSystemUser(String userID, String intermediatePath)
+            throws AuthorizableExistsException, RepositoryException {
         User user = delegate.createSystemUser(userID, intermediatePath);
         mount.createSystemUser(userID, user.getPath());
         return user;
@@ -100,13 +104,15 @@ public class ProxyUserManager extends ProxyWrapper<UserManager> implements UserM
         return group;
     }
 
-    public Group createGroup(Principal principal, String intermediatePath) throws AuthorizableExistsException, RepositoryException {
+    public Group createGroup(Principal principal, String intermediatePath)
+            throws AuthorizableExistsException, RepositoryException {
         Group group = delegate.createGroup(principal, intermediatePath);
         mount.createGroup(principal, group.getPath());
         return group;
     }
 
-    public Group createGroup(String groupID, Principal principal, String intermediatePath) throws AuthorizableExistsException, RepositoryException {
+    public Group createGroup(String groupID, Principal principal, String intermediatePath)
+            throws AuthorizableExistsException, RepositoryException {
         Group group = delegate.createGroup(groupID, principal, intermediatePath);
         mount.createGroup(groupID, principal, group.getPath());
         return group;

--- a/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyWorkspace.java
+++ b/src/main/java/org/apache/sling/jcr/base/internal/mount/ProxyWorkspace.java
@@ -18,9 +18,6 @@
  */
 package org.apache.sling.jcr.base.internal.mount;
 
-import java.io.IOException;
-import java.io.InputStream;
-
 import javax.jcr.AccessDeniedException;
 import javax.jcr.InvalidItemStateException;
 import javax.jcr.InvalidSerializedDataException;
@@ -41,6 +38,9 @@ import javax.jcr.query.QueryManager;
 import javax.jcr.version.Version;
 import javax.jcr.version.VersionException;
 import javax.jcr.version.VersionManager;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 import org.xml.sax.ContentHandler;
 
@@ -70,17 +70,24 @@ public class ProxyWorkspace<T extends Workspace> extends ProxyWrapper<T> impleme
     // TODO: revisit the below
 
     @Override
-    public ContentHandler getImportContentHandler(String parentAbsPath, int uuidBehavior) throws PathNotFoundException, ConstraintViolationException, VersionException, LockException, AccessDeniedException, RepositoryException {
+    public ContentHandler getImportContentHandler(String parentAbsPath, int uuidBehavior)
+            throws PathNotFoundException, ConstraintViolationException, VersionException, LockException,
+                    AccessDeniedException, RepositoryException {
         return this.mountSession.getImportContentHandler(parentAbsPath, uuidBehavior);
     }
 
     @Override
-    public void importXML(String parentAbsPath, InputStream in, int uuidBehavior) throws IOException, VersionException, PathNotFoundException, ItemExistsException, ConstraintViolationException, InvalidSerializedDataException, LockException, AccessDeniedException, RepositoryException {
+    public void importXML(String parentAbsPath, InputStream in, int uuidBehavior)
+            throws IOException, VersionException, PathNotFoundException, ItemExistsException,
+                    ConstraintViolationException, InvalidSerializedDataException, LockException, AccessDeniedException,
+                    RepositoryException {
         this.mountSession.importXML(parentAbsPath, in, uuidBehavior);
     }
 
     @Override
-    public void copy(String srcAbsPath, String destAbsPath) throws ConstraintViolationException, VersionException, AccessDeniedException, PathNotFoundException, ItemExistsException, LockException, RepositoryException {
+    public void copy(String srcAbsPath, String destAbsPath)
+            throws ConstraintViolationException, VersionException, AccessDeniedException, PathNotFoundException,
+                    ItemExistsException, LockException, RepositoryException {
         if (mountSession.isMount(srcAbsPath) && mountSession.isMount(destAbsPath)) {
             delegate2.copy(srcAbsPath, destAbsPath);
         } else {
@@ -89,7 +96,9 @@ public class ProxyWorkspace<T extends Workspace> extends ProxyWrapper<T> impleme
     }
 
     @Override
-    public void copy(String srcWorkspace, String srcAbsPath, String destAbsPath) throws NoSuchWorkspaceException, ConstraintViolationException, VersionException, AccessDeniedException, PathNotFoundException, ItemExistsException, LockException, RepositoryException {
+    public void copy(String srcWorkspace, String srcAbsPath, String destAbsPath)
+            throws NoSuchWorkspaceException, ConstraintViolationException, VersionException, AccessDeniedException,
+                    PathNotFoundException, ItemExistsException, LockException, RepositoryException {
         if (mountSession.isMount(srcAbsPath) && mountSession.isMount(destAbsPath)) {
             delegate2.copy(srcWorkspace, srcAbsPath, destAbsPath);
         } else {
@@ -98,7 +107,9 @@ public class ProxyWorkspace<T extends Workspace> extends ProxyWrapper<T> impleme
     }
 
     @Override
-    public void clone(String srcWorkspace, String srcAbsPath, String destAbsPath, boolean removeExisting) throws NoSuchWorkspaceException, ConstraintViolationException, VersionException, AccessDeniedException, PathNotFoundException, ItemExistsException, LockException, RepositoryException {
+    public void clone(String srcWorkspace, String srcAbsPath, String destAbsPath, boolean removeExisting)
+            throws NoSuchWorkspaceException, ConstraintViolationException, VersionException, AccessDeniedException,
+                    PathNotFoundException, ItemExistsException, LockException, RepositoryException {
         if (mountSession.isMount(srcAbsPath) && mountSession.isMount(destAbsPath)) {
             delegate2.clone(srcWorkspace, srcAbsPath, destAbsPath, removeExisting);
         } else {
@@ -107,7 +118,9 @@ public class ProxyWorkspace<T extends Workspace> extends ProxyWrapper<T> impleme
     }
 
     @Override
-    public void move(String srcAbsPath, String destAbsPath) throws ConstraintViolationException, VersionException, AccessDeniedException, PathNotFoundException, ItemExistsException, LockException, RepositoryException {
+    public void move(String srcAbsPath, String destAbsPath)
+            throws ConstraintViolationException, VersionException, AccessDeniedException, PathNotFoundException,
+                    ItemExistsException, LockException, RepositoryException {
         if (mountSession.isMount(srcAbsPath) && mountSession.isMount(destAbsPath)) {
             delegate2.move(srcAbsPath, destAbsPath);
         } else {
@@ -116,25 +129,31 @@ public class ProxyWorkspace<T extends Workspace> extends ProxyWrapper<T> impleme
     }
 
     @Override
-    public void restore(Version[] versions, boolean removeExisting) throws ItemExistsException, UnsupportedRepositoryOperationException, VersionException, LockException, InvalidItemStateException, RepositoryException {
+    public void restore(Version[] versions, boolean removeExisting)
+            throws ItemExistsException, UnsupportedRepositoryOperationException, VersionException, LockException,
+                    InvalidItemStateException, RepositoryException {
         delegate.restore(versions, removeExisting);
     }
 
     @Override
-    public void createWorkspace(String name) throws AccessDeniedException, UnsupportedRepositoryOperationException, RepositoryException {
+    public void createWorkspace(String name)
+            throws AccessDeniedException, UnsupportedRepositoryOperationException, RepositoryException {
         delegate.createWorkspace(name);
     }
 
     @Override
-    public void createWorkspace(String name, String srcWorkspace) throws AccessDeniedException, UnsupportedRepositoryOperationException, NoSuchWorkspaceException, RepositoryException {
+    public void createWorkspace(String name, String srcWorkspace)
+            throws AccessDeniedException, UnsupportedRepositoryOperationException, NoSuchWorkspaceException,
+                    RepositoryException {
         delegate.createWorkspace(name, srcWorkspace);
     }
 
     @Override
-    public void deleteWorkspace(String name) throws AccessDeniedException, UnsupportedRepositoryOperationException, NoSuchWorkspaceException, RepositoryException {
+    public void deleteWorkspace(String name)
+            throws AccessDeniedException, UnsupportedRepositoryOperationException, NoSuchWorkspaceException,
+                    RepositoryException {
         delegate.deleteWorkspace(name);
     }
-
 
     @Override
     public LockManager getLockManager() throws UnsupportedRepositoryOperationException, RepositoryException {
@@ -152,7 +171,8 @@ public class ProxyWorkspace<T extends Workspace> extends ProxyWrapper<T> impleme
     }
 
     @Override
-    public ObservationManager getObservationManager() throws UnsupportedRepositoryOperationException, RepositoryException {
+    public ObservationManager getObservationManager()
+            throws UnsupportedRepositoryOperationException, RepositoryException {
         return delegate.getObservationManager();
     }
 

--- a/src/main/java/org/apache/sling/jcr/base/package-info.java
+++ b/src/main/java/org/apache/sling/jcr/base/package-info.java
@@ -18,14 +18,11 @@
  */
 
 /**
- * The {@code org.apache.sling.jcr.base} package provides basic support
- * to expose JCR repositories in Sling. The primary classes to implement are
- * {@code org.apache.sling.jcr.base.AbstractSlingRepositoryManager} to
- * manage the actual JCR repository instance and
- * {@link org.apache.sling.jcr.base.AbstractSlingRepository2} being the
- * basis for the repository service instance handed to using bundles.
+ * The {@code org.apache.sling.jcr.base} package provides basic support to expose JCR repositories
+ * in Sling. The primary classes to implement are {@code
+ * org.apache.sling.jcr.base.AbstractSlingRepositoryManager} to manage the actual JCR repository
+ * instance and {@link org.apache.sling.jcr.base.AbstractSlingRepository2} being the basis for the
+ * repository service instance handed to using bundles.
  */
 @org.osgi.annotation.versioning.Version("3.5.0")
 package org.apache.sling.jcr.base;
-
-

--- a/src/main/java/org/apache/sling/jcr/base/spi/RepositoryMount.java
+++ b/src/main/java/org/apache/sling/jcr/base/spi/RepositoryMount.java
@@ -21,36 +21,31 @@ package org.apache.sling.jcr.base.spi;
 import org.apache.jackrabbit.api.JackrabbitRepository;
 
 /**
- * A {@code RepositoryMount} works similar to a resource provider and allows to
- * connect custom data. But it works on the lower JCR API level. This way legacy
- * code using JCR API can be supported as well. However, implementors of this
- * interface need to implement the full JCR API - which is more complex than the
- * resource provider. Therefore a repository mount should only be used for
- * special cases where legacy code using JCR API is used.
- * <p>
- * The JCR base implementation supports only a single {@code RepositoryMount}.
- * In case of several registrations, the one with the highest service ranking
- * will be used.
- * <p>
- * The {@code RepositoryMount} must implement
- * {@link JackrabbitRepository#login(javax.jcr.Credentials, String, java.util.Map)}
- * in order to login against the custom data provider. It will get access to the
- * JCR session through {@link #PARENT_SESSION_KEY}.
+ * A {@code RepositoryMount} works similar to a resource provider and allows to connect custom data.
+ * But it works on the lower JCR API level. This way legacy code using JCR API can be supported as
+ * well. However, implementors of this interface need to implement the full JCR API - which is more
+ * complex than the resource provider. Therefore a repository mount should only be used for special
+ * cases where legacy code using JCR API is used.
+ *
+ * <p>The JCR base implementation supports only a single {@code RepositoryMount}. In case of several
+ * registrations, the one with the highest service ranking will be used.
+ *
+ * <p>The {@code RepositoryMount} must implement {@link
+ * JackrabbitRepository#login(javax.jcr.Credentials, String, java.util.Map)} in order to login
+ * against the custom data provider. It will get access to the JCR session through {@link
+ * #PARENT_SESSION_KEY}.
  */
-public interface RepositoryMount extends JackrabbitRepository
-{
+public interface RepositoryMount extends JackrabbitRepository {
     /**
-     * The key of the attribute holding the parent session when
-     * {@link JackrabbitRepository#login(javax.jcr.Credentials, String, java.util.Map)}
-     * is called.
+     * The key of the attribute holding the parent session when {@link
+     * JackrabbitRepository#login(javax.jcr.Credentials, String, java.util.Map)} is called.
      */
     String PARENT_SESSION_KEY = "org.apache.sling.jcr.base.RepositoryMount.PARENT_SESSION";
 
     /**
-     * The repository needs to register itself with this property which is a String+
-     * property defining the paths in the JCR tree where the handling of the nodes
-     * is delegated to the mounter. The mounter can mount itself at various points
-     * in the JCR repository.
+     * The repository needs to register itself with this property which is a String+ property defining
+     * the paths in the JCR tree where the handling of the nodes is delegated to the mounter. The
+     * mounter can mount itself at various points in the JCR repository.
      */
     String MOUNT_POINTS_KEY = "org.apache.sling.jcr.base.RepositoryMount.MOUNT_POINTS";
 }

--- a/src/main/java/org/apache/sling/jcr/base/spi/package-info.java
+++ b/src/main/java/org/apache/sling/jcr/base/spi/package-info.java
@@ -18,10 +18,8 @@
  */
 
 /**
- * The {@code org.apache.sling.jcr.base.spi} package provides a 
- * way to bifurcate requests to subpaths to a mount provider.
+ * The {@code org.apache.sling.jcr.base.spi} package provides a way to bifurcate requests to
+ * subpaths to a mount provider.
  */
 @org.osgi.annotation.versioning.Version("0.1.0")
 package org.apache.sling.jcr.base.spi;
-
-

--- a/src/main/java/org/apache/sling/jcr/base/util/AccessControlUtil.java
+++ b/src/main/java/org/apache/sling/jcr/base/util/AccessControlUtil.java
@@ -18,18 +18,6 @@
  */
 package org.apache.sling.jcr.base.util;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.security.Principal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
 import javax.jcr.AccessDeniedException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
@@ -44,6 +32,18 @@ import javax.jcr.security.AccessControlPolicy;
 import javax.jcr.security.AccessControlPolicyIterator;
 import javax.jcr.security.Privilege;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
 import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlList;
@@ -52,13 +52,10 @@ import org.apache.jackrabbit.api.security.user.UserManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * A simple utility class providing utilities with respect to
- * access control over repositories.
- */
+/** A simple utility class providing utilities with respect to access control over repositories. */
 public class AccessControlUtil {
 
-	// the name of the accessor method for the AccessControlManager
+    // the name of the accessor method for the AccessControlManager
     private static final String METHOD_GET_ACCESS_CONTROL_MANAGER = "getAccessControlManager";
     // the name of the accessor method for the UserManager
     private static final String METHOD_GET_USER_MANAGER = "getUserManager";
@@ -81,566 +78,618 @@ public class AccessControlUtil {
 
     // ---------- SessionImpl methods -----------------------------------------------------
 
-	/**
-     * Returns the <code>AccessControlManager</code> for the given
-     * <code>session</code>. If the session does not have a
-     * <code>getAccessControlManager</code> method, a
-     * <code>UnsupportedRepositoryOperationException</code> is thrown. Otherwise
-     * the <code>AccessControlManager</code> is returned or if the call fails,
-     * the respective exception is thrown.
+    /**
+     * Returns the <code>AccessControlManager</code> for the given <code>session</code>. If the
+     * session does not have a <code>getAccessControlManager</code> method, a <code>
+     * UnsupportedRepositoryOperationException</code> is thrown. Otherwise the <code>
+     * AccessControlManager</code> is returned or if the call fails, the respective exception is
+     * thrown.
      *
-     * @param session The JCR Session whose <code>AccessControlManager</code> is
-     *            to be returned. If the session is a pooled session, the
-     *            session underlying the pooled session is actually used.
+     * @param session The JCR Session whose <code>AccessControlManager</code> is to be returned. If
+     *     the session is a pooled session, the session underlying the pooled session is actually
+     *     used.
      * @return The <code>AccessControlManager</code> of the session
-     * @throws UnsupportedRepositoryOperationException If the session has no
-     *             <code>getAccessControlManager</code> method or the exception
-     *             thrown by the method.
-     * @throws RepositoryException Forwarded from the
-     *             <code>getAccessControlManager</code> method call.
+     * @throws UnsupportedRepositoryOperationException If the session has no <code>
+     *     getAccessControlManager</code> method or the exception thrown by the method.
+     * @throws RepositoryException Forwarded from the <code>getAccessControlManager</code> method
+     *     call.
      */
-	public static AccessControlManager getAccessControlManager(Session session)
-											throws UnsupportedRepositoryOperationException, RepositoryException {
+    public static AccessControlManager getAccessControlManager(Session session)
+            throws UnsupportedRepositoryOperationException, RepositoryException {
         return safeInvokeRepoMethod(session, METHOD_GET_ACCESS_CONTROL_MANAGER, AccessControlManager.class);
-	}
+    }
 
-	// ---------- JackrabbitSession methods -----------------------------------------------
+    // ---------- JackrabbitSession methods -----------------------------------------------
 
-	/**
-	 * Returns the <code>UserManager</code> for the given
-     * <code>session</code>. If the session does not have a
-     * <code>getUserManager</code> method, a
-     * <code>UnsupportedRepositoryOperationException</code> is thrown. Otherwise
-     * the <code>UserManager</code> is returned or if the call fails,
-     * the respective exception is thrown.
-	 *
-	 * @param session  The JCR Session whose <code>UserManager</code> is
-     *            to be returned. If the session is not a <code>JackrabbitSession</code>
-     *            uses reflection to retrive the manager from the repository.
-	 * @return The <code>UserManager</code> of the session.
-	 * @throws AccessDeniedException If this session is not allowed
-	 * 			  to access user data.
-	 * @throws UnsupportedRepositoryOperationException If the session has no
-     *            <code>getUserManager</code> method or the exception
-     *            thrown by the method.
-	 * @throws RepositoryException Forwarded from the
-     *             <code>getUserManager</code> method call.
-	 */
-	public static UserManager getUserManager(Session session)
-										throws AccessDeniedException, UnsupportedRepositoryOperationException, RepositoryException {
-		JackrabbitSession jackrabbitSession = getJackrabbitSession(session);
-		if(jackrabbitSession != null) {
-			return jackrabbitSession.getUserManager();
-		} else {
-			return safeInvokeRepoMethod(session, METHOD_GET_USER_MANAGER, UserManager.class);
-		}
-	}
+    /**
+     * Returns the <code>UserManager</code> for the given <code>session</code>. If the session does
+     * not have a <code>getUserManager</code> method, a <code>UnsupportedRepositoryOperationException
+     * </code> is thrown. Otherwise the <code>UserManager</code> is returned or if the call fails, the
+     * respective exception is thrown.
+     *
+     * @param session The JCR Session whose <code>UserManager</code> is to be returned. If the session
+     *     is not a <code>JackrabbitSession</code> uses reflection to retrive the manager from the
+     *     repository.
+     * @return The <code>UserManager</code> of the session.
+     * @throws AccessDeniedException If this session is not allowed to access user data.
+     * @throws UnsupportedRepositoryOperationException If the session has no <code>getUserManager
+     *     </code> method or the exception thrown by the method.
+     * @throws RepositoryException Forwarded from the <code>getUserManager</code> method call.
+     */
+    public static UserManager getUserManager(Session session)
+            throws AccessDeniedException, UnsupportedRepositoryOperationException, RepositoryException {
+        JackrabbitSession jackrabbitSession = getJackrabbitSession(session);
+        if (jackrabbitSession != null) {
+            return jackrabbitSession.getUserManager();
+        } else {
+            return safeInvokeRepoMethod(session, METHOD_GET_USER_MANAGER, UserManager.class);
+        }
+    }
 
-	/**
-	 * Returns the <code>PrincipalManager</code> for the given
-     * <code>session</code>. If the session does not have a
-     * <code>PrincipalManager</code> method, a
-     * <code>UnsupportedRepositoryOperationException</code> is thrown. Otherwise
-     * the <code>PrincipalManager</code> is returned or if the call fails,
-     * the respective exception is thrown.
-	 *
-	 * @param session  The JCR Session whose <code>PrincipalManager</code> is
-     *            to be returned. If the session is not a <code>JackrabbitSession</code>
-     *            uses reflection to retrive the manager from the repository.
-	 * @return The <code>PrincipalManager</code> of the session.
-	 * @throws AccessDeniedException If the current user lacks sufficient privileges
-	 * @throws UnsupportedRepositoryOperationException If the session has no
-	 * 				<code>PrincipalManager</code> method or the exception
-     *             	thrown by the method.
-	 * @throws RepositoryException Forwarded from the
-     *             <code>PrincipalManager</code> method call.
-	 */
-	public static PrincipalManager getPrincipalManager(Session session)
-										throws AccessDeniedException, UnsupportedRepositoryOperationException, RepositoryException {
-		JackrabbitSession jackrabbitSession = getJackrabbitSession(session);
-		if(jackrabbitSession != null) {
-			return jackrabbitSession.getPrincipalManager();
-		} else {
-			return safeInvokeRepoMethod(session, METHOD_GET_PRINCIPAL_MANAGER, PrincipalManager.class);
-		}
-	}
+    /**
+     * Returns the <code>PrincipalManager</code> for the given <code>session</code>. If the session
+     * does not have a <code>PrincipalManager</code> method, a <code>
+     * UnsupportedRepositoryOperationException</code> is thrown. Otherwise the <code>PrincipalManager
+     * </code> is returned or if the call fails, the respective exception is thrown.
+     *
+     * @param session The JCR Session whose <code>PrincipalManager</code> is to be returned. If the
+     *     session is not a <code>JackrabbitSession</code> uses reflection to retrive the manager from
+     *     the repository.
+     * @return The <code>PrincipalManager</code> of the session.
+     * @throws AccessDeniedException If the current user lacks sufficient privileges
+     * @throws UnsupportedRepositoryOperationException If the session has no <code>PrincipalManager
+     *     </code> method or the exception thrown by the method.
+     * @throws RepositoryException Forwarded from the <code>PrincipalManager</code> method call.
+     */
+    public static PrincipalManager getPrincipalManager(Session session)
+            throws AccessDeniedException, UnsupportedRepositoryOperationException, RepositoryException {
+        JackrabbitSession jackrabbitSession = getJackrabbitSession(session);
+        if (jackrabbitSession != null) {
+            return jackrabbitSession.getPrincipalManager();
+        } else {
+            return safeInvokeRepoMethod(session, METHOD_GET_PRINCIPAL_MANAGER, PrincipalManager.class);
+        }
+    }
 
-	// ---------- AccessControlList methods -----------------------------------------------
+    // ---------- AccessControlList methods -----------------------------------------------
 
-	/**
-	 * Returns the path of the node <code>AccessControlList</code> acl
-	 * has been created for.
-	 * @param acl The acl to get the path for
-	 * @return the path for the acl
-	 * @throws RepositoryException Forwarded from the
-     *             <code>getPath</code> method call.
-	 */
-	public static String getPath(AccessControlList acl) throws RepositoryException {
-			return safeInvokeRepoMethod(acl, METHOD_JACKRABBIT_ACL_GET_PATH, String.class);
-	}
+    /**
+     * Returns the path of the node <code>AccessControlList</code> acl has been created for.
+     *
+     * @param acl The acl to get the path for
+     * @return the path for the acl
+     * @throws RepositoryException Forwarded from the <code>getPath</code> method call.
+     */
+    public static String getPath(AccessControlList acl) throws RepositoryException {
+        return safeInvokeRepoMethod(acl, METHOD_JACKRABBIT_ACL_GET_PATH, String.class);
+    }
 
-	/**
-	 * Returns <code>true</code> if <code>AccessControlList</code> acl
-	 * does not yet define any entries.
-	 * @param acl The acl to check
-	 * @return true if the acl is empty, false otherwise
-	 * @throws RepositoryException Forwarded from the
-     *             <code>isEmpty</code> method call.
-	 */
+    /**
+     * Returns <code>true</code> if <code>AccessControlList</code> acl does not yet define any
+     * entries.
+     *
+     * @param acl The acl to check
+     * @return true if the acl is empty, false otherwise
+     * @throws RepositoryException Forwarded from the <code>isEmpty</code> method call.
+     */
     public static boolean isEmpty(AccessControlList acl) throws RepositoryException {
-		return safeInvokeRepoMethod(acl, METHOD_JACKRABBIT_ACL_IS_EMPTY, Boolean.class);
+        return safeInvokeRepoMethod(acl, METHOD_JACKRABBIT_ACL_IS_EMPTY, Boolean.class);
     }
 
     /**
      * Returns the number of acl entries or 0 if the acl is empty.
-	 * @param acl The acl to get the size of
-	 * @return the size of the acl
-	 * @throws RepositoryException Forwarded from the
-     *             <code>size</code> method call.
+     *
+     * @param acl The acl to get the size of
+     * @return the size of the acl
+     * @throws RepositoryException Forwarded from the <code>size</code> method call.
      */
     public static int size(AccessControlList acl) throws RepositoryException {
-		return safeInvokeRepoMethod(acl, METHOD_JACKRABBIT_ACL_SIZE, Integer.class);
+        return safeInvokeRepoMethod(acl, METHOD_JACKRABBIT_ACL_SIZE, Integer.class);
     }
 
     /**
-     * Same as {@link #addEntry(AccessControlList, Principal, Privilege[], boolean, Map)} using
-     * some implementation specific restrictions.
-     * 
+     * Same as {@link #addEntry(AccessControlList, Principal, Privilege[], boolean, Map)} using some
+     * implementation specific restrictions.
+     *
      * @param acl the list to add the new entry to
      * @param principal the principal for the user or group to add the entry for
-     * @param privileges the set of privileges to grant or deny 
+     * @param privileges the set of privileges to grant or deny
      * @param isAllow try to grant the privileges or false to deny the privileges
-     * 
-     * @return <code>true</code> if this policy was modified,
-     * <code>false</code> otherwise.
-     * 
-     * @throws AccessControlException If any of the given parameter is invalid
-     * or cannot be handled by the implementation.
+     * @return <code>true</code> if this policy was modified, <code>false</code> otherwise.
+     * @throws AccessControlException If any of the given parameter is invalid or cannot be handled by
+     *     the implementation.
      * @throws RepositoryException if any other error occurs.
      */
-	public static boolean addEntry(AccessControlList acl, Principal principal, Privilege privileges[], boolean isAllow)
-        							throws AccessControlException, RepositoryException {
-    	Object[] args = new Object[] {principal, privileges, isAllow};
-    	@SuppressWarnings("rawtypes")
+    public static boolean addEntry(AccessControlList acl, Principal principal, Privilege privileges[], boolean isAllow)
+            throws AccessControlException, RepositoryException {
+        Object[] args = new Object[] {principal, privileges, isAllow};
+        @SuppressWarnings("rawtypes")
         Class[] types = new Class[] {Principal.class, Privilege[].class, boolean.class};
-		return safeInvokeRepoMethod(acl, METHOD_JACKRABBIT_ACL_ADD_ENTRY, Boolean.class, args, types);
+        return safeInvokeRepoMethod(acl, METHOD_JACKRABBIT_ACL_ADD_ENTRY, Boolean.class, args, types);
     }
 
     /**
-     * Adds an access control entry to the acl consisting of the specified
-     * <code>principal</code>, the specified <code>privileges</code>, the
-     * <code>isAllow</code> flag and an optional map containing additional
-     * restrictions.
-     * 
+     * Adds an access control entry to the acl consisting of the specified <code>principal</code>, the
+     * specified <code>privileges</code>, the <code>isAllow</code> flag and an optional map containing
+     * additional restrictions.
+     *
      * @param acl the list to add the new entry to
      * @param principal the principal for the user or group to add the entry for
-     * @param privileges the set of privileges to grant or deny 
+     * @param privileges the set of privileges to grant or deny
      * @param isAllow try to grant the privileges or false to deny the privileges
-     * @param restrictions (optional) additional restrictions to filter the scope of the added entry.  The value of the map must be a {@link Value} or {@link Value[]}
-     * 
-     * @return <code>true</code> if this policy was modified,
-     * <code>false</code> otherwise.
-     * 
-     * @throws UnsupportedRepositoryOperationException if the repository doesn't support adding access control entries
+     * @param restrictions (optional) additional restrictions to filter the scope of the added entry.
+     *     The value of the map must be a {@link Value} or {@link Value[]}
+     * @return <code>true</code> if this policy was modified, <code>false</code> otherwise.
+     * @throws UnsupportedRepositoryOperationException if the repository doesn't support adding access
+     *     control entries
      * @throws RepositoryException if any other error occurs.
      */
-	public static boolean addEntry(AccessControlList acl, Principal principal, Privilege privileges[], boolean isAllow, @SuppressWarnings("rawtypes") Map restrictions)
-    															throws UnsupportedRepositoryOperationException, RepositoryException {
-		Map<String, Value> restrictionsMap = null;
-		Map<String, Value[]> mvRestrictionsMap = null;
-		if (restrictions != null) {
-			// restrictions arg expected to be Map<String, Value>
-			// mvRestrictions arg expected to be Map<String, Value[]>
-			Set<?> entrySet = ((Map<?, ?>)restrictions).entrySet();
-			for (Object entry : entrySet) {
-				Map.Entry<?, ?> me = (Map.Entry<?, ?>)entry;
-				Object value = me.getValue();
-				if (value != null) {
-					String key = String.valueOf(me.getKey());
-					if (value instanceof Value) {
-						if (restrictionsMap == null) {
-							restrictionsMap = new HashMap<>();
-						}
-						restrictionsMap.put(key, (Value)value);
-					} else if (value instanceof Value[]) {
-						if (mvRestrictionsMap == null) {
-							mvRestrictionsMap = new HashMap<>();
-						}
-						mvRestrictionsMap.put(key, (Value[])value);
-					} else {
-						//some other data type?
-						throw new IllegalArgumentException("the values in the restrictions argument must be either a Value or Value[] object");
-					}
-				}
-			}
-		}
-		
-		return addEntry(acl, principal, privileges, isAllow, restrictionsMap, mvRestrictionsMap);
+    public static boolean addEntry(
+            AccessControlList acl,
+            Principal principal,
+            Privilege privileges[],
+            boolean isAllow,
+            @SuppressWarnings("rawtypes") Map restrictions)
+            throws UnsupportedRepositoryOperationException, RepositoryException {
+        Map<String, Value> restrictionsMap = null;
+        Map<String, Value[]> mvRestrictionsMap = null;
+        if (restrictions != null) {
+            // restrictions arg expected to be Map<String, Value>
+            // mvRestrictions arg expected to be Map<String, Value[]>
+            Set<?> entrySet = ((Map<?, ?>) restrictions).entrySet();
+            for (Object entry : entrySet) {
+                Map.Entry<?, ?> me = (Map.Entry<?, ?>) entry;
+                Object value = me.getValue();
+                if (value != null) {
+                    String key = String.valueOf(me.getKey());
+                    if (value instanceof Value) {
+                        if (restrictionsMap == null) {
+                            restrictionsMap = new HashMap<>();
+                        }
+                        restrictionsMap.put(key, (Value) value);
+                    } else if (value instanceof Value[]) {
+                        if (mvRestrictionsMap == null) {
+                            mvRestrictionsMap = new HashMap<>();
+                        }
+                        mvRestrictionsMap.put(key, (Value[]) value);
+                    } else {
+                        // some other data type?
+                        throw new IllegalArgumentException(
+                                "the values in the restrictions argument must be either a Value or Value[] object");
+                    }
+                }
+            }
+        }
+
+        return addEntry(acl, principal, privileges, isAllow, restrictionsMap, mvRestrictionsMap);
     }
 
     /**
-     * Adds an access control entry to the acl consisting of the specified
-     * <code>principal</code>, the specified <code>privileges</code>, the
-     * <code>isAllow</code> flag and an optional map containing additional
-     * restrictions.
-     * 
+     * Adds an access control entry to the acl consisting of the specified <code>principal</code>, the
+     * specified <code>privileges</code>, the <code>isAllow</code> flag and an optional map containing
+     * additional restrictions.
+     *
      * @param acl the list to add the new entry to
      * @param principal the principal for the user or group to add the entry for
-     * @param privileges the set of privileges to grant or deny 
+     * @param privileges the set of privileges to grant or deny
      * @param isAllow try to grant the privileges or false to deny the privileges
-     * @param restrictions (optional) additional single-value restrictions to filter the scope of the added entry
-     * @param mvRestrictions (optional) additional multi-value restrictions to filter the scope of the added entry
-     * 
-     * @return <code>true</code> if this policy was modified,
-     * <code>false</code> otherwise.
-     * @throws UnsupportedRepositoryOperationException if the repository doesn't support adding access control entries
+     * @param restrictions (optional) additional single-value restrictions to filter the scope of the
+     *     added entry
+     * @param mvRestrictions (optional) additional multi-value restrictions to filter the scope of the
+     *     added entry
+     * @return <code>true</code> if this policy was modified, <code>false</code> otherwise.
+     * @throws UnsupportedRepositoryOperationException if the repository doesn't support adding access
+     *     control entries
      * @throws RepositoryException if any other error occurs.
      */
-	public static boolean addEntry(AccessControlList acl, Principal principal, Privilege privileges[], boolean isAllow, 
-			Map<String, Value> restrictions, Map<String, Value[]> mvRestrictions)
-    															throws UnsupportedRepositoryOperationException, RepositoryException {
-		Object[] args = null;
-		Class<?>[] types = null;
-		if (mvRestrictions == null && restrictions == null) {
-			//no restrictions specified
-			args = new Object[] {principal, privileges, isAllow};
-			types = new Class[] {Principal.class, Privilege[].class, boolean.class};
-		} else if (mvRestrictions == null) {
-			//only single-value restrictions (valid with jackrabbit-api version 2.0.0 or later)
-			args = new Object[] {principal, privileges, isAllow, restrictions};
-			types = new Class[] {Principal.class, Privilege[].class, boolean.class, Map.class};
-		} else {
-			//both single-value and multi-value restrictions (valid with jackrabbit-api version 2.8.0 or later)_
-			args = new Object[] {principal, privileges, isAllow, restrictions, mvRestrictions};
-			types = new Class[] {Principal.class, Privilege[].class, boolean.class, Map.class, Map.class};
-		}
-		
-		return safeInvokeRepoMethod(acl, METHOD_JACKRABBIT_ACL_ADD_ENTRY, Boolean.class, args, types);
+    public static boolean addEntry(
+            AccessControlList acl,
+            Principal principal,
+            Privilege privileges[],
+            boolean isAllow,
+            Map<String, Value> restrictions,
+            Map<String, Value[]> mvRestrictions)
+            throws UnsupportedRepositoryOperationException, RepositoryException {
+        Object[] args = null;
+        Class<?>[] types = null;
+        if (mvRestrictions == null && restrictions == null) {
+            // no restrictions specified
+            args = new Object[] {principal, privileges, isAllow};
+            types = new Class[] {Principal.class, Privilege[].class, boolean.class};
+        } else if (mvRestrictions == null) {
+            // only single-value restrictions (valid with jackrabbit-api version 2.0.0 or later)
+            args = new Object[] {principal, privileges, isAllow, restrictions};
+            types = new Class[] {Principal.class, Privilege[].class, boolean.class, Map.class};
+        } else {
+            // both single-value and multi-value restrictions (valid with jackrabbit-api version 2.8.0 or
+            // later)_
+            args = new Object[] {principal, privileges, isAllow, restrictions, mvRestrictions};
+            types = new Class[] {Principal.class, Privilege[].class, boolean.class, Map.class, Map.class};
+        }
+
+        return safeInvokeRepoMethod(acl, METHOD_JACKRABBIT_ACL_ADD_ENTRY, Boolean.class, args, types);
     }
 
     /**
-     * Replaces existing access control entries in the ACL for the specified
-     * <code>principal</code> and <code>resourcePath</code>. Any existing granted
-     * or denied privileges which do not conflict with the specified privileges
-     * are maintained. Where conflicts exist, existing privileges are dropped.
-     * The end result will be at most two ACEs for the principal: one for grants
-     * and one for denies. Aggregate privileges are disaggregated before checking
-     * for conflicts.
+     * Replaces existing access control entries in the ACL for the specified <code>principal</code>
+     * and <code>resourcePath</code>. Any existing granted or denied privileges which do not conflict
+     * with the specified privileges are maintained. Where conflicts exist, existing privileges are
+     * dropped. The end result will be at most two ACEs for the principal: one for grants and one for
+     * denies. Aggregate privileges are disaggregated before checking for conflicts.
+     *
      * @param session the JCR session of the user doing the work
      * @param resourcePath the path of the resource to replace the entry on
      * @param principal the principal for the user or group to add the entry for
      * @param grantedPrivilegeNames the names of the privileges to grant
      * @param deniedPrivilegeNames the names of the privileges to deny
-     * @param removedPrivilegeNames privileges which, if they exist, should be
-     * removed for this principal and resource
+     * @param removedPrivilegeNames privileges which, if they exist, should be removed for this
+     *     principal and resource
      * @throws RepositoryException if any error occurs.
-     * @deprecated use @link {@link #replaceAccessControlEntry(Session, String, Principal, String[], String[], String[], String)} instead.
+     * @deprecated use @link {@link #replaceAccessControlEntry(Session, String, Principal, String[],
+     *     String[], String[], String)} instead.
      */
     @Deprecated
-    public static void replaceAccessControlEntry(Session session, String resourcePath, Principal principal,
-			String[] grantedPrivilegeNames, String[] deniedPrivilegeNames, String[] removedPrivilegeNames)
-    		throws RepositoryException {
-    	replaceAccessControlEntry(session,
-    			resourcePath,
-    			principal,
-    			grantedPrivilegeNames,
-    			deniedPrivilegeNames,
-    			removedPrivilegeNames,
-    			null);
+    public static void replaceAccessControlEntry(
+            Session session,
+            String resourcePath,
+            Principal principal,
+            String[] grantedPrivilegeNames,
+            String[] deniedPrivilegeNames,
+            String[] removedPrivilegeNames)
+            throws RepositoryException {
+        replaceAccessControlEntry(
+                session,
+                resourcePath,
+                principal,
+                grantedPrivilegeNames,
+                deniedPrivilegeNames,
+                removedPrivilegeNames,
+                null);
     }
 
     /**
-     * Replaces existing access control entries in the ACL for the specified
-     * <code>principal</code> and <code>resourcePath</code>. Any existing granted
-     * or denied privileges which do not conflict with the specified privileges
-     * are maintained. Where conflicts exist, existing privileges are dropped.
-     * The end result will be at most two ACEs for the principal: one for grants
-     * and one for denies. Aggregate privileges are disaggregated before checking
-     * for conflicts.
+     * Replaces existing access control entries in the ACL for the specified <code>principal</code>
+     * and <code>resourcePath</code>. Any existing granted or denied privileges which do not conflict
+     * with the specified privileges are maintained. Where conflicts exist, existing privileges are
+     * dropped. The end result will be at most two ACEs for the principal: one for grants and one for
+     * denies. Aggregate privileges are disaggregated before checking for conflicts.
+     *
      * @param session the JCR session of the user doing the work
      * @param resourcePath the path of the resource to replace the entry on
      * @param principal the principal for the user or group to add the entry for
      * @param grantedPrivilegeNames the names of the privileges to grant
      * @param deniedPrivilegeNames the names of the privileges to deny
-     * @param removedPrivilegeNames privileges which, if they exist, should be
-     * removed for this principal and resource
-     * @param order where the access control entry should go in the list.
-     *         Value should be one of these:
-     *         <table>
+     * @param removedPrivilegeNames privileges which, if they exist, should be removed for this
+     *     principal and resource
+     * @param order where the access control entry should go in the list. Value should be one of
+     *     these:
+     *     <table>
      *          <caption>Values</caption>
      *          <tr><td>null</td><td>If the ACE for the principal doesn't exist add at the end, otherwise leave the ACE at it's current position.</td></tr>
      * 			<tr><td>first</td><td>Place the target ACE as the first amongst its siblings</td></tr>
-	 *			<tr><td>last</td><td>Place the target ACE as the last amongst its siblings</td></tr>
-	 * 			<tr><td>before xyz</td><td>Place the target ACE immediately before the sibling whose name is xyz</td></tr>
-	 * 			<tr><td>after xyz</td><td>Place the target ACE immediately after the sibling whose name is xyz</td></tr>
-	 * 			<tr><td>numeric</td><td>Place the target ACE at the specified numeric index</td></tr>
-	 *         </table>
+     * 		<tr><td>last</td><td>Place the target ACE as the last amongst its siblings</td></tr>
+     * 			<tr><td>before xyz</td><td>Place the target ACE immediately before the sibling whose name is xyz</td></tr>
+     * 			<tr><td>after xyz</td><td>Place the target ACE immediately after the sibling whose name is xyz</td></tr>
+     * 			<tr><td>numeric</td><td>Place the target ACE at the specified numeric index</td></tr>
+     *         </table>
+     *
      * @throws RepositoryException if any error occurs.
      */
-    public static void replaceAccessControlEntry(Session session, String resourcePath, Principal principal,
-    			String[] grantedPrivilegeNames, String[] deniedPrivilegeNames, String[] removedPrivilegeNames,
-    			String order)
-        		throws RepositoryException {
-    	replaceAccessControlEntry(session, resourcePath, principal, grantedPrivilegeNames, deniedPrivilegeNames, removedPrivilegeNames, order, null, null, null);
+    public static void replaceAccessControlEntry(
+            Session session,
+            String resourcePath,
+            Principal principal,
+            String[] grantedPrivilegeNames,
+            String[] deniedPrivilegeNames,
+            String[] removedPrivilegeNames,
+            String order)
+            throws RepositoryException {
+        replaceAccessControlEntry(
+                session,
+                resourcePath,
+                principal,
+                grantedPrivilegeNames,
+                deniedPrivilegeNames,
+                removedPrivilegeNames,
+                order,
+                null,
+                null,
+                null);
     }
-    
+
     /**
-     * Replaces existing access control entries in the ACL for the specified
-     * <code>principal</code> and <code>resourcePath</code>. Any existing granted
-     * or denied privileges which do not conflict with the specified privileges
-     * are maintained. Where conflicts exist, existing privileges are dropped.
-     * The end result will be at most two ACEs for the principal: one for grants
-     * and one for denies. Aggregate privileges are disaggregated before checking
-     * for conflicts.
+     * Replaces existing access control entries in the ACL for the specified <code>principal</code>
+     * and <code>resourcePath</code>. Any existing granted or denied privileges which do not conflict
+     * with the specified privileges are maintained. Where conflicts exist, existing privileges are
+     * dropped. The end result will be at most two ACEs for the principal: one for grants and one for
+     * denies. Aggregate privileges are disaggregated before checking for conflicts.
+     *
      * @param session the JCR session of the user doing the work
      * @param resourcePath the path of the resource to replace the entry on
      * @param principal the principal for the user or group to add the entry for
      * @param grantedPrivilegeNames the names of the privileges to grant
      * @param deniedPrivilegeNames the names of the privileges to deny
-     * @param removedPrivilegeNames privileges which, if they exist, should be
-     * removed for this principal and resource
-     * @param order where the access control entry should go in the list.
-     *         Value should be one of these:
-     *         <table>
+     * @param removedPrivilegeNames privileges which, if they exist, should be removed for this
+     *     principal and resource
+     * @param order where the access control entry should go in the list. Value should be one of
+     *     these:
+     *     <table>
      *          <caption>Values</caption>
      *          <tr><td>null</td><td>If the ACE for the principal doesn't exist add at the end, otherwise leave the ACE at it's current position.</td></tr>
      * 			<tr><td>first</td><td>Place the target ACE as the first amongst its siblings</td></tr>
-	 *			<tr><td>last</td><td>Place the target ACE as the last amongst its siblings</td></tr>
-	 * 			<tr><td>before xyz</td><td>Place the target ACE immediately before the sibling whose name is xyz</td></tr>
-	 * 			<tr><td>after xyz</td><td>Place the target ACE immediately after the sibling whose name is xyz</td></tr>
-	 * 			<tr><td>numeric</td><td>Place the target ACE at the specified numeric index</td></tr>
-	 *         </table>
-     * @param restrictions (optional) additional single-value restrictions to filter the scope of the replaced entry
-     * @param mvRestrictions (optional) additional multi-value restrictions to filter the scope of the replaced entry
-     * @param removedRestrictionNames optional set of restriction names that should be removed (if they already exist).
+     * 		<tr><td>last</td><td>Place the target ACE as the last amongst its siblings</td></tr>
+     * 			<tr><td>before xyz</td><td>Place the target ACE immediately before the sibling whose name is xyz</td></tr>
+     * 			<tr><td>after xyz</td><td>Place the target ACE immediately after the sibling whose name is xyz</td></tr>
+     * 			<tr><td>numeric</td><td>Place the target ACE at the specified numeric index</td></tr>
+     *         </table>
+     *
+     * @param restrictions (optional) additional single-value restrictions to filter the scope of the
+     *     replaced entry
+     * @param mvRestrictions (optional) additional multi-value restrictions to filter the scope of the
+     *     replaced entry
+     * @param removedRestrictionNames optional set of restriction names that should be removed (if
+     *     they already exist).
      * @throws RepositoryException if any error occurs.
      */
-    public static void replaceAccessControlEntry(Session session, String resourcePath, Principal principal,
-    			String[] grantedPrivilegeNames, String[] deniedPrivilegeNames, String[] removedPrivilegeNames,
-    			String order,
-    			Map<String, Value> restrictions,
-    			Map<String, Value[]> mvRestrictions,
-    			Set<String> removedRestrictionNames)
-        		throws RepositoryException {
-    	AccessControlManager accessControlManager = getAccessControlManager(session);
-    	Set<String> specifiedPrivilegeNames = new HashSet<String>();
-    	Set<String> newGrantedPrivilegeNames = disaggregateToPrivilegeNames(accessControlManager, grantedPrivilegeNames, specifiedPrivilegeNames);
-    	Set<String> newDeniedPrivilegeNames = disaggregateToPrivilegeNames(accessControlManager, deniedPrivilegeNames, specifiedPrivilegeNames);
-    	disaggregateToPrivilegeNames(accessControlManager, removedPrivilegeNames, specifiedPrivilegeNames);
+    public static void replaceAccessControlEntry(
+            Session session,
+            String resourcePath,
+            Principal principal,
+            String[] grantedPrivilegeNames,
+            String[] deniedPrivilegeNames,
+            String[] removedPrivilegeNames,
+            String order,
+            Map<String, Value> restrictions,
+            Map<String, Value[]> mvRestrictions,
+            Set<String> removedRestrictionNames)
+            throws RepositoryException {
+        AccessControlManager accessControlManager = getAccessControlManager(session);
+        Set<String> specifiedPrivilegeNames = new HashSet<String>();
+        Set<String> newGrantedPrivilegeNames =
+                disaggregateToPrivilegeNames(accessControlManager, grantedPrivilegeNames, specifiedPrivilegeNames);
+        Set<String> newDeniedPrivilegeNames =
+                disaggregateToPrivilegeNames(accessControlManager, deniedPrivilegeNames, specifiedPrivilegeNames);
+        disaggregateToPrivilegeNames(accessControlManager, removedPrivilegeNames, specifiedPrivilegeNames);
 
-    	//make a copy since we may need to merge and change the map before applying them
-    	Map<String, Value> newRestrictions = new HashMap<>();
-    	Map<String, Value[]> newMvRestrictions = new HashMap<>();
-    	if (restrictions != null) {
-    		Set<Entry<String, Value>> entrySet = restrictions.entrySet();
-    		for (Entry<String, Value> entry : entrySet) {
-				String key = entry.getKey();
-				if (removedRestrictionNames != null && removedRestrictionNames.contains(key)) {
-					// new restriction is also in the removed set, so no need to try to remove it
-					removedRestrictionNames.remove(key);
-				}
-				newRestrictions.put(key, entry.getValue());
-			}
-    	}
-    	if (mvRestrictions != null) {
-    		Set<Entry<String, Value[]>> entrySet = mvRestrictions.entrySet();
-    		for (Entry<String, Value[]> entry : entrySet) {
-				String key = entry.getKey();
-				if (removedRestrictionNames != null && removedRestrictionNames.contains(key)) {
-					// new restriction is also in the removed set, so no need to try to remove it
-					removedRestrictionNames.remove(key);
-				}
-				newMvRestrictions.put(key, entry.getValue());
-			}
-    	}
-    	
-    	// Get or create the ACL for the node.
-    	AccessControlList acl = null;
-    	AccessControlPolicy[] policies = accessControlManager.getPolicies(resourcePath);
-    	for (AccessControlPolicy policy : policies) {
-    		if (policy instanceof AccessControlList) {
-    			acl = (AccessControlList) policy;
-    			break;
-    		}
-    	}
-    	if (acl == null) {
-    		AccessControlPolicyIterator applicablePolicies = accessControlManager.getApplicablePolicies(resourcePath);
-    		while (applicablePolicies.hasNext()) {
-    			AccessControlPolicy policy = applicablePolicies.nextAccessControlPolicy();
-    			if (policy instanceof AccessControlList) {
-    				acl = (AccessControlList) policy;
-    				break;
-    			}
-    		}
-    	}
-    	if (acl == null) {
-    		throw new RepositoryException("Could not obtain ACL for resource " + resourcePath);
-    	}
-    	// Used only for logging.
-    	Set<Privilege> oldGrants = null;
-    	Set<Privilege> oldDenies = null;
-    	if (log.isDebugEnabled()) {
-    		oldGrants = new HashSet<Privilege>();
-    		oldDenies = new HashSet<Privilege>();
-    	}
+        // make a copy since we may need to merge and change the map before applying them
+        Map<String, Value> newRestrictions = new HashMap<>();
+        Map<String, Value[]> newMvRestrictions = new HashMap<>();
+        if (restrictions != null) {
+            Set<Entry<String, Value>> entrySet = restrictions.entrySet();
+            for (Entry<String, Value> entry : entrySet) {
+                String key = entry.getKey();
+                if (removedRestrictionNames != null && removedRestrictionNames.contains(key)) {
+                    // new restriction is also in the removed set, so no need to try to remove it
+                    removedRestrictionNames.remove(key);
+                }
+                newRestrictions.put(key, entry.getValue());
+            }
+        }
+        if (mvRestrictions != null) {
+            Set<Entry<String, Value[]>> entrySet = mvRestrictions.entrySet();
+            for (Entry<String, Value[]> entry : entrySet) {
+                String key = entry.getKey();
+                if (removedRestrictionNames != null && removedRestrictionNames.contains(key)) {
+                    // new restriction is also in the removed set, so no need to try to remove it
+                    removedRestrictionNames.remove(key);
+                }
+                newMvRestrictions.put(key, entry.getValue());
+            }
+        }
 
-    	// Combine all existing ACEs for the target principal.
-    	AccessControlEntry[] accessControlEntries = acl.getAccessControlEntries();
-    	for (int i=0; i < accessControlEntries.length; i++) {
-    		AccessControlEntry ace = accessControlEntries[i];
-    		if (principal.equals(ace.getPrincipal())) {
-    			if (log.isDebugEnabled()) {
-    				log.debug("Found Existing ACE for principal {} on resource {}", new Object[] {principal.getName(), resourcePath});
-    			}
-    			if (order == null || order.length() == 0) {
-    				//order not specified, so keep track of the original ACE position.
-    				order = String.valueOf(i);
-    			}
+        // Get or create the ACL for the node.
+        AccessControlList acl = null;
+        AccessControlPolicy[] policies = accessControlManager.getPolicies(resourcePath);
+        for (AccessControlPolicy policy : policies) {
+            if (policy instanceof AccessControlList) {
+                acl = (AccessControlList) policy;
+                break;
+            }
+        }
+        if (acl == null) {
+            AccessControlPolicyIterator applicablePolicies = accessControlManager.getApplicablePolicies(resourcePath);
+            while (applicablePolicies.hasNext()) {
+                AccessControlPolicy policy = applicablePolicies.nextAccessControlPolicy();
+                if (policy instanceof AccessControlList) {
+                    acl = (AccessControlList) policy;
+                    break;
+                }
+            }
+        }
+        if (acl == null) {
+            throw new RepositoryException("Could not obtain ACL for resource " + resourcePath);
+        }
+        // Used only for logging.
+        Set<Privilege> oldGrants = null;
+        Set<Privilege> oldDenies = null;
+        if (log.isDebugEnabled()) {
+            oldGrants = new HashSet<Privilege>();
+            oldDenies = new HashSet<Privilege>();
+        }
 
-    			boolean isAllow = isAllow(ace);
-    			Privilege[] privileges = ace.getPrivileges();
-    			if (log.isDebugEnabled()) {
-    				if (isAllow) {
-    					oldGrants.addAll(Arrays.asList(privileges));
-    				} else {
-    					oldDenies.addAll(Arrays.asList(privileges));
-    				}
-    			}
-    			for (Privilege privilege : privileges) {
-    				Set<String> maintainedPrivileges = disaggregateToPrivilegeNames(privilege);
-    				// If there is any overlap with the newly specified privileges, then
-    				// break the existing privilege down; otherwise, maintain as is.
-    				if (!maintainedPrivileges.removeAll(specifiedPrivilegeNames)) {
-    					// No conflicts, so preserve the original.
-    					maintainedPrivileges.clear();
-    					maintainedPrivileges.add(privilege.getName());
-    				}
-    				if (!maintainedPrivileges.isEmpty()) {
-    					if (isAllow) {
-    						newGrantedPrivilegeNames.addAll(maintainedPrivileges);
-    					} else {
-    						newDeniedPrivilegeNames.addAll(maintainedPrivileges);
-    					}
-    				}
-    			}
-    			
-				// If there is any existing restrictions that are not specified with the newly specified arguments, 
-    			// then maintain the original restriction values as they were.
-    			if (ace instanceof JackrabbitAccessControlEntry) {
-    				JackrabbitAccessControlEntry jace = (JackrabbitAccessControlEntry)ace;
-					String[] restrictionNames = jace.getRestrictionNames();
-					if (restrictionNames != null) {
-						for (String rname : restrictionNames) {
-							if (!(newRestrictions.containsKey(rname) || newMvRestrictions.containsKey(rname))) {
-								// the restriction doesn't have a new value, so remember the old value
-								try {
-									Value restriction = jace.getRestriction(rname);
-									newRestrictions.put(rname, restriction);
-								} catch (Exception vfe) {
-									if (vfe instanceof ValueFormatException) {
-										//try multival variant (only valid for jackrabbit-api 2.8.0 or later)
-										Value[] rvalue = safeInvokeRepoMethod(ace, METHOD_JACKRABBIT_ACE_GET_RESTRICTIONS, Value[].class, 
-												new Object[] {rname}, new Class[] {String.class});
-										newMvRestrictions.put(rname, rvalue);
-									} else {
-										//some other exception, so just re-throw the original
-										throw vfe;
-									}
-								}
-							} 
-						}
-					}
-    			}
-    			// Remove the old ACE.
-    			acl.removeAccessControlEntry(ace);
-    		}
-    	}
-    	
-    	//remove the map entry for any restrictions were requested to be removed and no new value was
-    	// supplied
-    	if (removedRestrictionNames != null) {
-			for (String rname : removedRestrictionNames) {
-				// remove if a new value was not also supplied
-				if (!((restrictions != null && restrictions.containsKey(rname)) ||
-					  (mvRestrictions != null && mvRestrictions.containsKey(rname)))) {
-					newRestrictions.remove(rname);
-					newMvRestrictions.remove(rname);
-				}
-			}
-    	}
+        // Combine all existing ACEs for the target principal.
+        AccessControlEntry[] accessControlEntries = acl.getAccessControlEntries();
+        for (int i = 0; i < accessControlEntries.length; i++) {
+            AccessControlEntry ace = accessControlEntries[i];
+            if (principal.equals(ace.getPrincipal())) {
+                if (log.isDebugEnabled()) {
+                    log.debug(
+                            "Found Existing ACE for principal {} on resource {}",
+                            new Object[] {principal.getName(), resourcePath});
+                }
+                if (order == null || order.length() == 0) {
+                    // order not specified, so keep track of the original ACE position.
+                    order = String.valueOf(i);
+                }
 
-    	//add a fresh ACE with the granted privileges
-    	List<Privilege> grantedPrivilegeList = new ArrayList<Privilege>();
-    	for (String name : newGrantedPrivilegeNames) {
-    		Privilege privilege = accessControlManager.privilegeFromName(name);
-    		grantedPrivilegeList.add(privilege);
-    	}
-    	if (grantedPrivilegeList.size() > 0) {
-   			addEntry(acl, principal, grantedPrivilegeList.toArray(new Privilege[grantedPrivilegeList.size()]), true, 
-   					newRestrictions, newMvRestrictions);
-    	}
-    	
-   		//add a fresh ACE with the denied privileges
-   		List<Privilege> deniedPrivilegeList = new ArrayList<Privilege>();
-   		for (String name : newDeniedPrivilegeNames) {
-   			Privilege privilege = accessControlManager.privilegeFromName(name);
-   			deniedPrivilegeList.add(privilege);
-   		}
-   		if (deniedPrivilegeList.size() > 0) {
-   			addEntry(acl, principal, deniedPrivilegeList.toArray(new Privilege[deniedPrivilegeList.size()]), false, 
-   					newRestrictions, newMvRestrictions);
-   		}
+                boolean isAllow = isAllow(ace);
+                Privilege[] privileges = ace.getPrivileges();
+                if (log.isDebugEnabled()) {
+                    if (isAllow) {
+                        oldGrants.addAll(Arrays.asList(privileges));
+                    } else {
+                        oldDenies.addAll(Arrays.asList(privileges));
+                    }
+                }
+                for (Privilege privilege : privileges) {
+                    Set<String> maintainedPrivileges = disaggregateToPrivilegeNames(privilege);
+                    // If there is any overlap with the newly specified privileges, then
+                    // break the existing privilege down; otherwise, maintain as is.
+                    if (!maintainedPrivileges.removeAll(specifiedPrivilegeNames)) {
+                        // No conflicts, so preserve the original.
+                        maintainedPrivileges.clear();
+                        maintainedPrivileges.add(privilege.getName());
+                    }
+                    if (!maintainedPrivileges.isEmpty()) {
+                        if (isAllow) {
+                            newGrantedPrivilegeNames.addAll(maintainedPrivileges);
+                        } else {
+                            newDeniedPrivilegeNames.addAll(maintainedPrivileges);
+                        }
+                    }
+                }
 
+                // If there is any existing restrictions that are not specified with the newly specified
+                // arguments,
+                // then maintain the original restriction values as they were.
+                if (ace instanceof JackrabbitAccessControlEntry) {
+                    JackrabbitAccessControlEntry jace = (JackrabbitAccessControlEntry) ace;
+                    String[] restrictionNames = jace.getRestrictionNames();
+                    if (restrictionNames != null) {
+                        for (String rname : restrictionNames) {
+                            if (!(newRestrictions.containsKey(rname) || newMvRestrictions.containsKey(rname))) {
+                                // the restriction doesn't have a new value, so remember the old value
+                                try {
+                                    Value restriction = jace.getRestriction(rname);
+                                    newRestrictions.put(rname, restriction);
+                                } catch (Exception vfe) {
+                                    if (vfe instanceof ValueFormatException) {
+                                        // try multival variant (only valid for jackrabbit-api 2.8.0 or later)
+                                        Value[] rvalue = safeInvokeRepoMethod(
+                                                ace,
+                                                METHOD_JACKRABBIT_ACE_GET_RESTRICTIONS,
+                                                Value[].class,
+                                                new Object[] {rname},
+                                                new Class[] {String.class});
+                                        newMvRestrictions.put(rname, rvalue);
+                                    } else {
+                                        // some other exception, so just re-throw the original
+                                        throw vfe;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                // Remove the old ACE.
+                acl.removeAccessControlEntry(ace);
+            }
+        }
 
-   		//order the ACL
-   		reorderAccessControlEntries(acl, principal, order);
+        // remove the map entry for any restrictions were requested to be removed and no new value was
+        // supplied
+        if (removedRestrictionNames != null) {
+            for (String rname : removedRestrictionNames) {
+                // remove if a new value was not also supplied
+                if (!((restrictions != null && restrictions.containsKey(rname))
+                        || (mvRestrictions != null && mvRestrictions.containsKey(rname)))) {
+                    newRestrictions.remove(rname);
+                    newMvRestrictions.remove(rname);
+                }
+            }
+        }
 
-    	accessControlManager.setPolicy(resourcePath, acl);
-    	if (log.isDebugEnabled()) {
-    		List<String> oldGrantedNames = new ArrayList<String>(oldGrants.size());
-    		for (Privilege privilege : oldGrants) {
-    			oldGrantedNames.add(privilege.getName());
-    		}
-    		List<String> oldDeniedNames = new ArrayList<String>(oldDenies.size());
-    		for (Privilege privilege : oldDenies) {
-    			oldDeniedNames.add(privilege.getName());
-    		}
-    		log.debug("Updated ACE for principalName {} for resource {} from grants {}, denies {} to grants {}, denies {}", new Object [] {
-    				principal.getName(), resourcePath, oldGrantedNames, oldDeniedNames, newGrantedPrivilegeNames, newDeniedPrivilegeNames
-    			});
-    	}
-	}
+        // add a fresh ACE with the granted privileges
+        List<Privilege> grantedPrivilegeList = new ArrayList<Privilege>();
+        for (String name : newGrantedPrivilegeNames) {
+            Privilege privilege = accessControlManager.privilegeFromName(name);
+            grantedPrivilegeList.add(privilege);
+        }
+        if (grantedPrivilegeList.size() > 0) {
+            addEntry(
+                    acl,
+                    principal,
+                    grantedPrivilegeList.toArray(new Privilege[grantedPrivilegeList.size()]),
+                    true,
+                    newRestrictions,
+                    newMvRestrictions);
+        }
+
+        // add a fresh ACE with the denied privileges
+        List<Privilege> deniedPrivilegeList = new ArrayList<Privilege>();
+        for (String name : newDeniedPrivilegeNames) {
+            Privilege privilege = accessControlManager.privilegeFromName(name);
+            deniedPrivilegeList.add(privilege);
+        }
+        if (deniedPrivilegeList.size() > 0) {
+            addEntry(
+                    acl,
+                    principal,
+                    deniedPrivilegeList.toArray(new Privilege[deniedPrivilegeList.size()]),
+                    false,
+                    newRestrictions,
+                    newMvRestrictions);
+        }
+
+        // order the ACL
+        reorderAccessControlEntries(acl, principal, order);
+
+        accessControlManager.setPolicy(resourcePath, acl);
+        if (log.isDebugEnabled()) {
+            List<String> oldGrantedNames = new ArrayList<String>(oldGrants.size());
+            for (Privilege privilege : oldGrants) {
+                oldGrantedNames.add(privilege.getName());
+            }
+            List<String> oldDeniedNames = new ArrayList<String>(oldDenies.size());
+            for (Privilege privilege : oldDenies) {
+                oldDeniedNames.add(privilege.getName());
+            }
+            log.debug(
+                    "Updated ACE for principalName {} for resource {} from grants {}, denies {} to grants {},"
+                            + " denies {}",
+                    new Object[] {
+                        principal.getName(),
+                        resourcePath,
+                        oldGrantedNames,
+                        oldDeniedNames,
+                        newGrantedPrivilegeNames,
+                        newDeniedPrivilegeNames
+                    });
+        }
+    }
 
     // ---------- AccessControlEntry methods -----------------------------------------------
 
     /**
-     * Returns true if the AccessControlEntry represents 'allowed' rights or false
-     * it it represents 'denied' rights.
-     * 
+     * Returns true if the AccessControlEntry represents 'allowed' rights or false it it represents
+     * 'denied' rights.
+     *
      * @param ace the access control entry to check
      * @return true if the entry represents allowed rights of ralse otherwise
-	 * @throws RepositoryException Forwarded from the
-     *             <code>isAllow</code> method call.
+     * @throws RepositoryException Forwarded from the <code>isAllow</code> method call.
      */
     public static boolean isAllow(AccessControlEntry ace) throws RepositoryException {
-		return safeInvokeRepoMethod(ace, METHOD_JACKRABBIT_ACE_IS_ALLOW, Boolean.class);
+        return safeInvokeRepoMethod(ace, METHOD_JACKRABBIT_ACE_IS_ALLOW, Boolean.class);
     }
 
     // ---------- internal -----------------------------------------------------
 
-    /**
-     * Use reflection to invoke a repository method.
-     */
+    /** Use reflection to invoke a repository method. */
     @SuppressWarnings("unchecked")
-	private static <T> T safeInvokeRepoMethod(Object target, String methodName, Class<T> returnType, Object[] args, @SuppressWarnings("rawtypes") Class[] argsTypes)
-    													throws UnsupportedRepositoryOperationException, RepositoryException {
-    	try {
-    		Method m = target.getClass().getMethod(methodName, argsTypes);
-    		if (!m.isAccessible()) {
-    			m.setAccessible(true);
-    		}
-			return (T) m.invoke(target, args);
-    	} catch (InvocationTargetException ite) {
+    private static <T> T safeInvokeRepoMethod(
+            Object target,
+            String methodName,
+            Class<T> returnType,
+            Object[] args,
+            @SuppressWarnings("rawtypes") Class[] argsTypes)
+            throws UnsupportedRepositoryOperationException, RepositoryException {
+        try {
+            Method m = target.getClass().getMethod(methodName, argsTypes);
+            if (!m.isAccessible()) {
+                m.setAccessible(true);
+            }
+            return (T) m.invoke(target, args);
+        } catch (InvocationTargetException ite) {
             // wraps the exception thrown by the method
             Throwable t = ite.getCause();
             if (t instanceof UnsupportedRepositoryOperationException) {
@@ -662,184 +711,180 @@ public class AccessControlUtil {
             // any other problem is just encapsulated
             throw new RepositoryException(methodName, t);
         }
-	}
+    }
 
     private static <T> T safeInvokeRepoMethod(Object target, String methodName, Class<T> returnType, Object... args)
-																		throws UnsupportedRepositoryOperationException, RepositoryException {
-    	return safeInvokeRepoMethod(target, methodName, returnType, args, new Class[0]);
+            throws UnsupportedRepositoryOperationException, RepositoryException {
+        return safeInvokeRepoMethod(target, methodName, returnType, args, new Class[0]);
+    }
+
+    /** Unwrap the jackrabbit session. */
+    private static JackrabbitSession getJackrabbitSession(Session session) {
+        if (session instanceof JackrabbitSession) return (JackrabbitSession) session;
+        else return null;
     }
 
     /**
-     * Unwrap the jackrabbit session.
+     * Helper routine to transform an input array of privilege names into a set in a null-safe way
+     * while also adding its disaggregated privileges to an input set.
      */
-	private static JackrabbitSession getJackrabbitSession(Session session) {
-		if (session instanceof JackrabbitSession)
-			return (JackrabbitSession) session;
-		else
-			return null;
-	}
+    private static Set<String> disaggregateToPrivilegeNames(
+            AccessControlManager accessControlManager, String[] privilegeNames, Set<String> disaggregatedPrivilegeNames)
+            throws RepositoryException {
+        Set<String> originalPrivilegeNames = new HashSet<String>();
+        if (privilegeNames != null) {
+            for (String privilegeName : privilegeNames) {
+                originalPrivilegeNames.add(privilegeName);
+                Privilege privilege = accessControlManager.privilegeFromName(privilegeName);
+                disaggregatedPrivilegeNames.addAll(disaggregateToPrivilegeNames(privilege));
+            }
+        }
+        return originalPrivilegeNames;
+    }
 
-	/**
-	 * Helper routine to transform an input array of privilege names into a set in
-	 * a null-safe way while also adding its disaggregated privileges to an input set.
-	 */
-	private static Set<String> disaggregateToPrivilegeNames(AccessControlManager accessControlManager,
-			String[] privilegeNames, Set<String> disaggregatedPrivilegeNames)
-      throws RepositoryException {
-		Set<String> originalPrivilegeNames = new HashSet<String>();
-		if (privilegeNames != null) {
-			for (String privilegeName : privilegeNames) {
-				originalPrivilegeNames.add(privilegeName);
-				Privilege privilege = accessControlManager.privilegeFromName(privilegeName);
-				disaggregatedPrivilegeNames.addAll(disaggregateToPrivilegeNames(privilege));
-			}
-		}
-		return originalPrivilegeNames;
-	}
+    /**
+     * Transform an aggregated privilege into a set of disaggregated privilege names. If the privilege
+     * is not an aggregate, the set will contain the original name.
+     */
+    private static Set<String> disaggregateToPrivilegeNames(Privilege privilege) {
+        Set<String> disaggregatedPrivilegeNames = new HashSet<String>();
+        if (privilege.isAggregate()) {
+            Privilege[] privileges = privilege.getAggregatePrivileges();
+            for (Privilege disaggregate : privileges) {
+                if (disaggregate.isAggregate()) {
+                    continue; // nested aggregate, so skip it since the privileges are already included.
+                }
+                disaggregatedPrivilegeNames.add(disaggregate.getName());
+            }
+        } else {
+            disaggregatedPrivilegeNames.add(privilege.getName());
+        }
+        return disaggregatedPrivilegeNames;
+    }
 
-	/**
-	 * Transform an aggregated privilege into a set of disaggregated privilege
-	 * names. If the privilege is not an aggregate, the set will contain the
-	 * original name.
-	 */
-	private static Set<String> disaggregateToPrivilegeNames(Privilege privilege) {
-		Set<String> disaggregatedPrivilegeNames = new HashSet<String>();
-		if (privilege.isAggregate()) {
-			Privilege[] privileges = privilege.getAggregatePrivileges();
-			for (Privilege disaggregate : privileges) {
-				if (disaggregate.isAggregate()) {
-					continue; //nested aggregate, so skip it since the privileges are already included.
-				}
-				disaggregatedPrivilegeNames.add(disaggregate.getName());
-			}
-		} else {
-			disaggregatedPrivilegeNames.add(privilege.getName());
-		}
-		return disaggregatedPrivilegeNames;
-	}
-
-	/**
-	 * Move the ACE(s) for the specified principal to the position specified by the 'order'
-	 * parameter.
-	 *
-	 * @param acl the acl of the node containing the ACE to position
-	 * @param principal the user or group of the ACE to position
-     * @param order where the access control entry should go in the list.
-     *         Value should be one of these:
-     *         <table>
+    /**
+     * Move the ACE(s) for the specified principal to the position specified by the 'order' parameter.
+     *
+     * @param acl the acl of the node containing the ACE to position
+     * @param principal the user or group of the ACE to position
+     * @param order where the access control entry should go in the list. Value should be one of
+     *     these:
+     *     <table>
      *          <caption>Values</caption>
      * 			<tr><td>first</td><td>Place the target ACE as the first amongst its siblings</td></tr>
-	 *			<tr><td>last</td><td>Place the target ACE as the last amongst its siblings</td></tr>
-	 * 			<tr><td>before xyz</td><td>Place the target ACE immediately before the sibling whose name is xyz</td></tr>
-	 * 			<tr><td>after xyz</td><td>Place the target ACE immediately after the sibling whose name is xyz</td></tr>
-	 * 			<tr><td>numeric</td><td>Place the target ACE at the specified index</td></tr>
-	 *         </table>
-	 * @throws RepositoryException
-	 * @throws UnsupportedRepositoryOperationException
-	 * @throws AccessControlException
-	 */
-	private static void reorderAccessControlEntries(AccessControlList acl,
-														Principal principal,
-														String order)
-							throws RepositoryException {
-		if (order == null || order.length() == 0) {
-			return; //nothing to do
-		}
-		if (acl instanceof JackrabbitAccessControlList) {
-			JackrabbitAccessControlList jacl = (JackrabbitAccessControlList)acl;
+     * 		<tr><td>last</td><td>Place the target ACE as the last amongst its siblings</td></tr>
+     * 			<tr><td>before xyz</td><td>Place the target ACE immediately before the sibling whose name is xyz</td></tr>
+     * 			<tr><td>after xyz</td><td>Place the target ACE immediately after the sibling whose name is xyz</td></tr>
+     * 			<tr><td>numeric</td><td>Place the target ACE at the specified index</td></tr>
+     *         </table>
+     *
+     * @throws RepositoryException
+     * @throws UnsupportedRepositoryOperationException
+     * @throws AccessControlException
+     */
+    private static void reorderAccessControlEntries(AccessControlList acl, Principal principal, String order)
+            throws RepositoryException {
+        if (order == null || order.length() == 0) {
+            return; // nothing to do
+        }
+        if (acl instanceof JackrabbitAccessControlList) {
+            JackrabbitAccessControlList jacl = (JackrabbitAccessControlList) acl;
 
-			AccessControlEntry[] accessControlEntries = jacl.getAccessControlEntries();
-			if (accessControlEntries.length <= 1) {
-				return; //only one ACE, so nothing to reorder.
-			}
+            AccessControlEntry[] accessControlEntries = jacl.getAccessControlEntries();
+            if (accessControlEntries.length <= 1) {
+                return; // only one ACE, so nothing to reorder.
+            }
 
-			AccessControlEntry beforeEntry = null;
-			if ("first".equals(order)) {
-				beforeEntry = accessControlEntries[0];
-			} else if ("last".equals(order)) {
-				beforeEntry = null;
-			} else if (order.startsWith("before ")) {
-				String beforePrincipalName = order.substring(7);
+            AccessControlEntry beforeEntry = null;
+            if ("first".equals(order)) {
+                beforeEntry = accessControlEntries[0];
+            } else if ("last".equals(order)) {
+                beforeEntry = null;
+            } else if (order.startsWith("before ")) {
+                String beforePrincipalName = order.substring(7);
 
-				//find the index of the ACE of the 'before' principal
-				for (int i=0; i < accessControlEntries.length; i++) {
-					if (beforePrincipalName.equals(accessControlEntries[i].getPrincipal().getName())) {
-						//found it!
-						beforeEntry = accessControlEntries[i];
-						break;
-					}
-				}
+                // find the index of the ACE of the 'before' principal
+                for (int i = 0; i < accessControlEntries.length; i++) {
+                    if (beforePrincipalName.equals(
+                            accessControlEntries[i].getPrincipal().getName())) {
+                        // found it!
+                        beforeEntry = accessControlEntries[i];
+                        break;
+                    }
+                }
 
-				if (beforeEntry == null) {
-					//didn't find an ACE that matched the 'before' principal
-					throw new IllegalArgumentException("No ACE was found for the specified principal: " + beforePrincipalName);
-				}
-			} else if (order.startsWith("after ")) {
-				String afterPrincipalName = order.substring(6);
+                if (beforeEntry == null) {
+                    // didn't find an ACE that matched the 'before' principal
+                    throw new IllegalArgumentException(
+                            "No ACE was found for the specified principal: " + beforePrincipalName);
+                }
+            } else if (order.startsWith("after ")) {
+                String afterPrincipalName = order.substring(6);
 
-				//find the index of the ACE of the 'after' principal
-				for (int i = accessControlEntries.length - 1; i >= 0; i--) {
-					if (afterPrincipalName.equals(accessControlEntries[i].getPrincipal().getName())) {
-						//found it!
+                // find the index of the ACE of the 'after' principal
+                for (int i = accessControlEntries.length - 1; i >= 0; i--) {
+                    if (afterPrincipalName.equals(
+                            accessControlEntries[i].getPrincipal().getName())) {
+                        // found it!
 
-						// the 'before' ACE is the next one after the 'after' ACE
-						if (i >= accessControlEntries.length - 1) {
-							//the after is the last one in the list
-							beforeEntry = null;
-						} else {
-							beforeEntry = accessControlEntries[i + 1];
-						}
-						break;
-					}
-				}
+                        // the 'before' ACE is the next one after the 'after' ACE
+                        if (i >= accessControlEntries.length - 1) {
+                            // the after is the last one in the list
+                            beforeEntry = null;
+                        } else {
+                            beforeEntry = accessControlEntries[i + 1];
+                        }
+                        break;
+                    }
+                }
 
-				if (beforeEntry == null) {
-					//didn't find an ACE that matched the 'after' principal
-					throw new IllegalArgumentException("No ACE was found for the specified principal: " + afterPrincipalName);
-				}
-			} else {
-				try {
-					int index = Integer.parseInt(order);
-					if (index > accessControlEntries.length) {
-						//invalid index
-						throw new IndexOutOfBoundsException("Index value is too large: " + index);
-					}
+                if (beforeEntry == null) {
+                    // didn't find an ACE that matched the 'after' principal
+                    throw new IllegalArgumentException(
+                            "No ACE was found for the specified principal: " + afterPrincipalName);
+                }
+            } else {
+                try {
+                    int index = Integer.parseInt(order);
+                    if (index > accessControlEntries.length) {
+                        // invalid index
+                        throw new IndexOutOfBoundsException("Index value is too large: " + index);
+                    }
 
-					if (index == 0) {
-						beforeEntry = accessControlEntries[0];
-					} else {
-						//the index value is the index of the principal.  A principal may have more
-						// than one ACEs (deny + grant), so we need to compensate.
-						Set<Principal> processedPrincipals = new HashSet<Principal>();
-						for (int i = 0; i < accessControlEntries.length; i++) {
-							Principal principal2 = accessControlEntries[i].getPrincipal();
-							if (processedPrincipals.size() == index &&
-									!processedPrincipals.contains(principal2)) {
-								//we are now at the correct position in the list
-								beforeEntry = accessControlEntries[i];
-								break;
-							}
+                    if (index == 0) {
+                        beforeEntry = accessControlEntries[0];
+                    } else {
+                        // the index value is the index of the principal.  A principal may have more
+                        // than one ACEs (deny + grant), so we need to compensate.
+                        Set<Principal> processedPrincipals = new HashSet<Principal>();
+                        for (int i = 0; i < accessControlEntries.length; i++) {
+                            Principal principal2 = accessControlEntries[i].getPrincipal();
+                            if (processedPrincipals.size() == index && !processedPrincipals.contains(principal2)) {
+                                // we are now at the correct position in the list
+                                beforeEntry = accessControlEntries[i];
+                                break;
+                            }
 
-							processedPrincipals.add(principal2);
-						}
-					}
-				} catch (NumberFormatException nfe) {
-					//not a number.
-					throw new IllegalArgumentException("Illegal value for the order parameter: " + order);
-				}
-			}
+                            processedPrincipals.add(principal2);
+                        }
+                    }
+                } catch (NumberFormatException nfe) {
+                    // not a number.
+                    throw new IllegalArgumentException("Illegal value for the order parameter: " + order);
+                }
+            }
 
-			//now loop through the entries to move the affected ACEs to the specified
-			// position.
-			for (int i = accessControlEntries.length - 1; i >= 0; i--) {
-				AccessControlEntry ace = accessControlEntries[i];
-				if (principal.equals(ace.getPrincipal())) {
-					//this ACE is for the specified principal.
-					jacl.orderBefore(ace, beforeEntry);
-				}
-			}
-		} else {
-			throw new IllegalArgumentException("The acl must be an instance of JackrabbitAccessControlList");
-		}
-	}
+            // now loop through the entries to move the affected ACEs to the specified
+            // position.
+            for (int i = accessControlEntries.length - 1; i >= 0; i--) {
+                AccessControlEntry ace = accessControlEntries[i];
+                if (principal.equals(ace.getPrincipal())) {
+                    // this ACE is for the specified principal.
+                    jacl.orderBefore(ace, beforeEntry);
+                }
+            }
+        } else {
+            throw new IllegalArgumentException("The acl must be an instance of JackrabbitAccessControlList");
+        }
+    }
 }

--- a/src/main/java/org/apache/sling/jcr/base/util/RepositoryAccessor.java
+++ b/src/main/java/org/apache/sling/jcr/base/util/RepositoryAccessor.java
@@ -18,14 +18,15 @@
  */
 package org.apache.sling.jcr.base.util;
 
+import javax.jcr.Repository;
+
+import java.util.Hashtable;
+
 import org.apache.jackrabbit.rmi.client.ClientRepositoryFactory;
 import org.apache.jackrabbit.rmi.client.LocalAdapterFactory;
 
-import javax.jcr.Repository;
-import java.util.Hashtable;
-
-/** 
- * Access a Repository via JNDI or RMI. 
+/**
+ * Access a Repository via JNDI or RMI.
  *
  * @deprecated No longer supported
  */
@@ -41,37 +42,33 @@ public class RepositoryAccessor {
     public static final String JNDI_PREFIX = "jndi://";
 
     /**
-     * Name of the property that the jcr client and server bundles to override
-     * their default configuration settings and connect to the specified
-     * repository instead (SLING-254 and SLING-260)
+     * Name of the property that the jcr client and server bundles to override their default
+     * configuration settings and connect to the specified repository instead (SLING-254 and
+     * SLING-260)
      */
     public static final String REPOSITORY_URL_OVERRIDE_PROPERTY = "sling.repository.url";
 
     /**
-     * First try to access the Repository via JNDI (unless jndiContext is null),
-     * and if not successful try RMI.
+     * First try to access the Repository via JNDI (unless jndiContext is null), and if not successful
+     * try RMI.
      *
-     * @param repositoryName JNDI name or RMI URL (must start with "rmi://") of
-     *            the Repository
+     * @param repositoryName JNDI name or RMI URL (must start with "rmi://") of the Repository
      * @param jndiContext if null, JNDI is not tried
      * @return a Repository, or null if not found
      * @throws UnsupportedOperationException Always throws {@code UnsupportedOperationException}
      * @deprecated No longer supported
      */
     @Deprecated
-    public Repository getRepository(String repositoryName,
-            Hashtable<String, Object> jndiContext) {
+    public Repository getRepository(String repositoryName, Hashtable<String, Object> jndiContext) {
         throw new UnsupportedOperationException("Repository access via JNDI-context is no longer supported.");
     }
 
     /**
      * Acquire a Repository from the given URL
      *
-     * @param url for RMI, an RMI URL. For JNDI, "jndi://", followed by the JNDI
-     *            repository name, followed by a colon and a comma-separated
-     *            list of JNDI context values, for example:
-     *
-     * <pre>
+     * @param url for RMI, an RMI URL. For JNDI, "jndi://", followed by the JNDI repository name,
+     *     followed by a colon and a comma-separated list of JNDI context values, for example:
+     *     <pre>
      *      jndi://jackrabbit:java.naming.factory.initial=org.SomeClass,java.naming.provider.url=http://foo.com
      * </pre>
      *
@@ -85,16 +82,15 @@ public class RepositoryAccessor {
     }
 
     /**
-     * Returns the <code>LocalAdapterFactory</code> used to convert Jackrabbit
-     * JCR RMI remote objects to local JCR API objects.
-     * <p>
-     * This method returns an instance of the
-     * <code>JackrabbitClientAdapterFactory</code> which allows accessing
-     * Jackrabbit (or Jackrabbit-based) repositories over RMI. Extensions of
-     * this class may overwrite this method to use a different implementation.
-     * 
-     * @return the <code>LocalAdapterFactory</code> used to convert Jackrabbit
-     * JCR RMI remote objects to local JCR API objects.
+     * Returns the <code>LocalAdapterFactory</code> used to convert Jackrabbit JCR RMI remote objects
+     * to local JCR API objects.
+     *
+     * <p>This method returns an instance of the <code>JackrabbitClientAdapterFactory</code> which
+     * allows accessing Jackrabbit (or Jackrabbit-based) repositories over RMI. Extensions of this
+     * class may overwrite this method to use a different implementation.
+     *
+     * @return the <code>LocalAdapterFactory</code> used to convert Jackrabbit JCR RMI remote objects
+     *     to local JCR API objects.
      * @throws UnsupportedOperationException Always throws {@code UnsupportedOperationException}
      * @deprecated No longer supported
      */
@@ -104,20 +100,16 @@ public class RepositoryAccessor {
     }
 
     /**
-     * Returns the <code>ClientRepositoryFactory</code> to access the remote
-     * JCR repository over RMI.
-     * <p>
-     * This method creates an instance of the
-     * <code>ClientRepositoryFactory</code> class initialized with the
-     * <code>LocalAdapterFactory</code> returned from the
-     * {@link #getLocalAdapterFactory()} method. Extensions may overwrite this
-     * method to return an extension of the Jackrabbit JCR RMI
-     * <code>ClientRepositoryFactory</code> class.
-     * 
-     * @return the <code>ClientRepositoryFactory</code> to access the remote
-     * JCR repository over RMI.
+     * Returns the <code>ClientRepositoryFactory</code> to access the remote JCR repository over RMI.
+     *
+     * <p>This method creates an instance of the <code>ClientRepositoryFactory</code> class
+     * initialized with the <code>LocalAdapterFactory</code> returned from the {@link
+     * #getLocalAdapterFactory()} method. Extensions may overwrite this method to return an extension
+     * of the Jackrabbit JCR RMI <code>ClientRepositoryFactory</code> class.
+     *
+     * @return the <code>ClientRepositoryFactory</code> to access the remote JCR repository over RMI.
      * @throws UnsupportedOperationException Always throws {@code UnsupportedOperationException}
-     * @deprecated No longer supported 
+     * @deprecated No longer supported
      */
     @Deprecated
     protected ClientRepositoryFactory getClientRepositoryFactory() {

--- a/src/main/java/org/apache/sling/jcr/base/util/package-info.java
+++ b/src/main/java/org/apache/sling/jcr/base/util/package-info.java
@@ -21,4 +21,3 @@
 package org.apache.sling.jcr.base.util;
 
 import org.osgi.annotation.versioning.Version;
-

--- a/src/test/java/org/apache/sling/jcr/base/MockSlingRepository2.java
+++ b/src/test/java/org/apache/sling/jcr/base/MockSlingRepository2.java
@@ -23,13 +23,13 @@ import javax.jcr.Session;
 
 import org.osgi.framework.Bundle;
 
-/** Minimal AbstractSlingRepositoryManager used for testing */ 
+/** Minimal AbstractSlingRepositoryManager used for testing */
 class MockSlingRepository2 extends AbstractSlingRepository2 {
 
     MockSlingRepository2(MockSlingRepositoryManager manager, Bundle usingBundle, Session session) {
         super(manager, usingBundle);
     }
-    
+
     @Override
     protected Session createAdministrativeSession(String workspace) throws RepositoryException {
         // Assuming we run on a test repo with no access control
@@ -37,7 +37,8 @@ class MockSlingRepository2 extends AbstractSlingRepository2 {
     }
 
     @Override
-    protected Session createServiceSession(Iterable<String> principalNames, String workspace) throws RepositoryException {
+    protected Session createServiceSession(Iterable<String> principalNames, String workspace)
+            throws RepositoryException {
         return getRepository().login();
     }
 }

--- a/src/test/java/org/apache/sling/jcr/base/MockSlingRepositoryManager.java
+++ b/src/test/java/org/apache/sling/jcr/base/MockSlingRepositoryManager.java
@@ -18,7 +18,8 @@
  */
 package org.apache.sling.jcr.base;
 
-import static org.junit.Assert.fail;
+import javax.jcr.Repository;
+import javax.jcr.RepositoryException;
 
 import java.util.Arrays;
 import java.util.Dictionary;
@@ -26,12 +27,11 @@ import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Set;
 
-import javax.jcr.Repository;
-import javax.jcr.RepositoryException;
-
 import org.apache.sling.serviceusermapping.ServiceUserMapper;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+
+import static org.junit.Assert.fail;
 
 /** Minimal AbstractSlingRepositoryManager used for testing */
 public class MockSlingRepositoryManager extends AbstractSlingRepositoryManager {
@@ -50,7 +50,8 @@ public class MockSlingRepositoryManager extends AbstractSlingRepositoryManager {
         this(repository, false, ALLOWLIST_ALL);
     }
 
-    public MockSlingRepositoryManager(Repository repository, boolean loginAdminDisabled, String... loginAdminAllowList) {
+    public MockSlingRepositoryManager(
+            Repository repository, boolean loginAdminDisabled, String... loginAdminAllowList) {
         this.repository = repository;
         this.loginAdminDisabled = loginAdminDisabled;
         this.loginAdminAllowList = new HashSet<>(Arrays.asList(loginAdminAllowList));
@@ -74,10 +75,10 @@ public class MockSlingRepositoryManager extends AbstractSlingRepositoryManager {
 
     @Override
     protected AbstractSlingRepository2 create(Bundle usingBundle) {
-        if(repository != null) {
+        if (repository != null) {
             try {
                 return new MockSlingRepository2(this, usingBundle, repository.login());
-            } catch(RepositoryException rex) {
+            } catch (RepositoryException rex) {
                 fail(rex.toString());
             }
         }
@@ -85,12 +86,10 @@ public class MockSlingRepositoryManager extends AbstractSlingRepositoryManager {
     }
 
     @Override
-    protected void destroy(AbstractSlingRepository2 repositoryServiceInstance) {
-    }
+    protected void destroy(AbstractSlingRepository2 repositoryServiceInstance) {}
 
     @Override
-    protected void disposeRepository(Repository repository) {
-    }
+    protected void disposeRepository(Repository repository) {}
 
     @Override
     protected boolean allowLoginAdministrativeForBundle(final Bundle bundle) {

--- a/src/test/java/org/apache/sling/jcr/base/NodeTypeLoaderTest.java
+++ b/src/test/java/org/apache/sling/jcr/base/NodeTypeLoaderTest.java
@@ -21,21 +21,24 @@ package org.apache.sling.jcr.base;
 import javax.jcr.RepositoryException;
 
 import org.junit.Test;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class NodeTypeLoaderTest {
-    
+
     @Test
     public void testisReRegisterBuiltinNodeType() {
-        assertFalse("Exception does not match", 
-                NodeTypeLoader.isReRegisterBuiltinNodeType(new Exception()));
-        assertFalse("Plain RepositoryException does not match", 
+        assertFalse("Exception does not match", NodeTypeLoader.isReRegisterBuiltinNodeType(new Exception()));
+        assertFalse(
+                "Plain RepositoryException does not match",
                 NodeTypeLoader.isReRegisterBuiltinNodeType(new RepositoryException()));
-        assertFalse("Non-reregister RepositoryException does not match", 
+        assertFalse(
+                "Non-reregister RepositoryException does not match",
                 NodeTypeLoader.isReRegisterBuiltinNodeType(new RepositoryException("builtin that's it")));
-        assertTrue("Reregister RepositoryException matches", 
-                NodeTypeLoader.isReRegisterBuiltinNodeType(
-                        new RepositoryException("{http://www.jcp.org/jcr/mix/1.0}language: can't reregister built-in node type")));
+        assertTrue(
+                "Reregister RepositoryException matches",
+                NodeTypeLoader.isReRegisterBuiltinNodeType(new RepositoryException(
+                        "{http://www.jcp.org/jcr/mix/1.0}language: can't reregister built-in node type")));
     }
 }

--- a/src/test/java/org/apache/sling/jcr/base/RepositoryInitializersTest.java
+++ b/src/test/java/org/apache/sling/jcr/base/RepositoryInitializersTest.java
@@ -18,16 +18,12 @@
  */
 package org.apache.sling.jcr.base;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Hashtable;
-import java.util.concurrent.atomic.AtomicReference;
-
 import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+
+import java.util.Hashtable;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.sling.commons.osgi.SortingServiceTracker;
 import org.apache.sling.jcr.api.SlingRepository;
@@ -43,95 +39,105 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceReference;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 /** Test the SlingRepositoryInitializer mechanism */
 public class RepositoryInitializersTest {
 
     @Rule
     public final SlingContext context = new SlingContext(ResourceResolverType.JCR_MOCK);
-    
+
     private static final String DEFAULT_WORKSPACE = "defws";
     private AbstractSlingRepositoryManager asrm;
     private Repository repository;
     private Session session;
     private SortingServiceTracker<SlingRepository> repoTracker;
-    
-    /** We initially get a SlingRepository service from the Sling Mocks, and we're
-     *  interested to find out whether the repository manager also registers one
-     *  in our tests.
+
+    /**
+     * We initially get a SlingRepository service from the Sling Mocks, and we're interested to find
+     * out whether the repository manager also registers one in our tests.
      */
     private int initialRepoServicesCount;
-    
+
     @Before
     public void setup() throws RepositoryException {
-        repoTracker = new SortingServiceTracker<SlingRepository>(context.bundleContext(), SlingRepository.class.getName());
+        repoTracker =
+                new SortingServiceTracker<SlingRepository>(context.bundleContext(), SlingRepository.class.getName());
         repoTracker.open();
         repository = MockJcr.newRepository();
         session = repository.login();
         asrm = new MockSlingRepositoryManager(repository);
-        
+
         initialRepoServicesCount = countRepositoryServices();
         assertAdditionalRepositoryServices(0);
     }
-    
+
     @After
     public void cleanup() {
         repoTracker.close();
         asrm.stop();
         session.logout();
     }
-    
+
     private void registerInitializer(String id, int serviceRanking) {
         final SlingRepositoryInitializer init = new TestInitializer(id);
         final Hashtable<String, Object> props = new Hashtable<String, Object>();
         props.put(Constants.SERVICE_RANKING, serviceRanking);
         context.bundleContext().registerService(SlingRepositoryInitializer.class.getName(), init, props);
     }
-    
+
     private void assertTestInitializerProperty(String expected) throws RepositoryException {
         final String path = TestInitializer.getPropertyPath();
         assertTrue("Expecting property at " + path, session.propertyExists(path));
-        assertEquals("Expecting correct value at " + path, expected, session.getProperty(path).getString());
+        assertEquals(
+                "Expecting correct value at " + path,
+                expected,
+                session.getProperty(path).getString());
     }
-    
+
     private int countRepositoryServices() {
-        final ServiceReference [] refs = repoTracker.getServiceReferences();
+        final ServiceReference[] refs = repoTracker.getServiceReferences();
         return (refs == null ? 0 : refs.length);
     }
-    
+
     private void assertAdditionalRepositoryServices(int expected) {
-        assertEquals("Expecting " + expected + " SlingRepository services", 
-                expected + initialRepoServicesCount, countRepositoryServices());
+        assertEquals(
+                "Expecting " + expected + " SlingRepository services",
+                expected + initialRepoServicesCount,
+                countRepositoryServices());
     }
-    
+
     private void assertStart(boolean expected) {
         final boolean actual = asrm.start(context.bundleContext(), DEFAULT_WORKSPACE, false);
         assertEquals("Expecting start to return " + expected, expected, actual);
     }
-    
+
     @Test
     public void inOrderInitializers() throws RepositoryException {
-        for(int i=1; i < 4; i++) {
+        for (int i = 1; i < 4; i++) {
             registerInitializer(String.valueOf(i), i * 100);
         }
-        
+
         assertStart(true);
-        
+
         assertTestInitializerProperty("1,2,3,");
         assertAdditionalRepositoryServices(1);
     }
-    
+
     @Test
     public void reverseOrderInitializers() throws RepositoryException {
-        for(int i=1; i < 4; i++) {
+        for (int i = 1; i < 4; i++) {
             registerInitializer(String.valueOf(i), i * -100);
         }
-        
+
         assertStart(true);
-        
+
         assertTestInitializerProperty("3,2,1,");
         assertAdditionalRepositoryServices(1);
     }
-    
+
     @Test
     public void noRepositoryOnException() throws RepositoryException {
         registerInitializer("a", 1);
@@ -139,20 +145,20 @@ public class RepositoryInitializersTest {
         registerInitializer("c", 3);
 
         assertStart(false);
-        
-        // The repository manager does not register a service in this case 
+
+        // The repository manager does not register a service in this case
         assertAdditionalRepositoryServices(0);
     }
-    
+
     @Test
     public void noRepositoryOnError() throws RepositoryException {
         registerInitializer("a", 1);
         registerInitializer("ERROR", 2);
         registerInitializer("c", 3);
-        
+
         assertStart(false);
-        
-        // The repository manager does not register a service in this case 
+
+        // The repository manager does not register a service in this case
         assertAdditionalRepositoryServices(0);
     }
 

--- a/src/test/java/org/apache/sling/jcr/base/RepositoryMountTest.java
+++ b/src/test/java/org/apache/sling/jcr/base/RepositoryMountTest.java
@@ -18,13 +18,14 @@
  */
 package org.apache.sling.jcr.base;
 
-import java.util.Dictionary;
-import java.util.Properties;
 import javax.jcr.Node;
 import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.nodetype.NodeType;
+
+import java.util.Dictionary;
+import java.util.Properties;
 
 import org.apache.sling.jcr.base.spi.RepositoryMount;
 import org.apache.sling.testing.mock.jcr.MockJcr;
@@ -36,8 +37,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.osgi.framework.ServiceRegistration;
 
-public class RepositoryMountTest
-{
+public class RepositoryMountTest {
     @Rule
     public final SlingContext context = new SlingContext(ResourceResolverType.JCR_MOCK);
 
@@ -46,8 +46,7 @@ public class RepositoryMountTest
     private MockSlingRepositoryManager manager;
 
     @Before
-    public void setup() throws RepositoryException
-    {
+    public void setup() throws RepositoryException {
         rootRepository = MockJcr.newRepository();
         mountRepository = MockJcr.newRepository();
 
@@ -57,15 +56,18 @@ public class RepositoryMountTest
     @Test
     public void testRepositoryMount() throws RepositoryException {
         Session rootSession = rootRepository.login();
-        rootSession.getRootNode()
-            .addNode("/root", NodeType.NT_UNSTRUCTURED)
-            .addNode("test", NodeType.NT_UNSTRUCTURED)
-            .setProperty("test", "root");
+        rootSession
+                .getRootNode()
+                .addNode("/root", NodeType.NT_UNSTRUCTURED)
+                .addNode("test", NodeType.NT_UNSTRUCTURED)
+                .setProperty("test", "root");
 
         Session mountSession = mountRepository.login();
-        mountSession.getRootNode().addNode("/mount")
-            .addNode("test", NodeType.NT_UNSTRUCTURED)
-            .setProperty("test", "test");
+        mountSession
+                .getRootNode()
+                .addNode("/mount")
+                .addNode("test", NodeType.NT_UNSTRUCTURED)
+                .setProperty("test", "test");
 
         Assert.assertFalse(rootSession.nodeExists("/mount"));
         Assert.assertFalse(mountSession.nodeExists("/root"));
@@ -86,7 +88,8 @@ public class RepositoryMountTest
         Properties props = new Properties();
         props.put(RepositoryMount.MOUNT_POINTS_KEY, "/mount");
 
-        ServiceRegistration reg = context.bundleContext().registerService(RepositoryMount.class.getName(), mountRepository, (Dictionary) props);
+        ServiceRegistration reg = context.bundleContext()
+                .registerService(RepositoryMount.class.getName(), mountRepository, (Dictionary) props);
 
         session = repository.login();
 
@@ -113,7 +116,8 @@ public class RepositoryMountTest
 
         session.logout();
 
-        reg = context.bundleContext().registerService(RepositoryMount.class.getName(), mountRepository, (Dictionary) props);
+        reg = context.bundleContext()
+                .registerService(RepositoryMount.class.getName(), mountRepository, (Dictionary) props);
 
         session = repository.login();
 
@@ -132,7 +136,13 @@ public class RepositoryMountTest
     }
 
     private void testTraversal(Session session, String path, String value) throws RepositoryException {
-        Assert.assertEquals(value, session.getRootNode().getNode(path).getNode("test").getProperty("test").getString());
+        Assert.assertEquals(
+                value,
+                session.getRootNode()
+                        .getNode(path)
+                        .getNode("test")
+                        .getProperty("test")
+                        .getString());
     }
 
     private void testCreate(Repository repo, String start, String... path) throws RepositoryException {

--- a/src/test/java/org/apache/sling/jcr/base/TestInitializer.java
+++ b/src/test/java/org/apache/sling/jcr/base/TestInitializer.java
@@ -24,9 +24,7 @@ import javax.jcr.Session;
 import org.apache.sling.jcr.api.SlingRepository;
 import org.apache.sling.jcr.api.SlingRepositoryInitializer;
 
-/** SlingRepositoryInitializer used to test that all initializers are
- *  called in the right order.
- */
+/** SlingRepositoryInitializer used to test that all initializers are called in the right order. */
 class TestInitializer implements SlingRepositoryInitializer {
 
     private final String id;
@@ -40,17 +38,17 @@ class TestInitializer implements SlingRepositoryInitializer {
 
     @Override
     public void processRepository(SlingRepository repo) throws Exception {
-        if(id.equals("EXCEPTION")) {
+        if (id.equals("EXCEPTION")) {
             throw new Exception("Failing due to id=" + id);
         }
-        if(id.equals("ERROR")) {
+        if (id.equals("ERROR")) {
             throw new Error("Erroring due to id=" + id);
         }
 
         final Session s = repo.loginAdministrative(null);
         try {
             Node n = null;
-            if(s.nodeExists(NODE_PATH)) {
+            if (s.nodeExists(NODE_PATH)) {
                 n = s.getNode(NODE_PATH);
             } else {
                 n = s.getRootNode().addNode(NODE_NAME);

--- a/src/test/java/org/apache/sling/jcr/base/internal/AllowListWiringTest.java
+++ b/src/test/java/org/apache/sling/jcr/base/internal/AllowListWiringTest.java
@@ -18,17 +18,13 @@
  */
 package org.apache.sling.jcr.base.internal;
 
-import static org.apache.sling.jcr.base.MockSlingRepositoryManager.ALLOWLIST_ALL;
-import static org.apache.sling.jcr.base.MockSlingRepositoryManager.ALLOWLIST_NONE;
-import static org.junit.Assert.assertEquals;
+import javax.jcr.LoginException;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import javax.jcr.LoginException;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 
 import org.apache.sling.jcr.api.SlingRepository;
 import org.apache.sling.jcr.base.AbstractSlingRepository2;
@@ -44,8 +40,13 @@ import org.mockito.Mockito;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 
-/** Verify that the AbstractSlingRepository2 uses the login admin allow list,
- *  as well as its combination with the global "disable login admin" flag
+import static org.apache.sling.jcr.base.MockSlingRepositoryManager.ALLOWLIST_ALL;
+import static org.apache.sling.jcr.base.MockSlingRepositoryManager.ALLOWLIST_NONE;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Verify that the AbstractSlingRepository2 uses the login admin allow list, as well as its
+ * combination with the global "disable login admin" flag
  */
 @RunWith(Parameterized.class)
 public class AllowListWiringTest {
@@ -55,25 +56,26 @@ public class AllowListWiringTest {
     private final boolean managerAllowsLoginAdmin;
     private final boolean allowListAllowsLoginAdmin;
     private final boolean loginAdminExpected;
- 
-    @Parameters(name="manager {0}, allow list {1} -> {2}")
+
+    @Parameters(name = "manager {0}, allow list {1} -> {2}")
     public static Collection<Object[]> data() {
         final List<Object[]> result = new ArrayList<Object[]>();
-        result.add(new Object[] { false, false, false });
-        result.add(new Object[] { false, true, false });
-        result.add(new Object[] { true, false, false });
-        result.add(new Object[] { true, true, true});
+        result.add(new Object[] {false, false, false});
+        result.add(new Object[] {false, true, false});
+        result.add(new Object[] {true, false, false});
+        result.add(new Object[] {true, true, true});
         return result;
     }
 
-    public AllowListWiringTest(boolean managerAllowsLoginAdmin, boolean allowListAllowsLoginAdmin, boolean loginAdminExpected) {
+    public AllowListWiringTest(
+            boolean managerAllowsLoginAdmin, boolean allowListAllowsLoginAdmin, boolean loginAdminExpected) {
         this.managerAllowsLoginAdmin = managerAllowsLoginAdmin;
         this.allowListAllowsLoginAdmin = allowListAllowsLoginAdmin;
         this.loginAdminExpected = loginAdminExpected;
     }
-    
+
     @Before
-    public void setup() throws Exception  {
+    public void setup() throws Exception {
         BundleContext bundleContext = MockOsgi.newBundleContext();
         Bundle bundle = bundleContext.getBundle();
 
@@ -83,7 +85,7 @@ public class AllowListWiringTest {
                 new MockSlingRepositoryManager(MockJcr.newRepository(), !managerAllowsLoginAdmin, allowList);
 
         repoMgr.activate(bundleContext);
-        
+
         repository = new AbstractSlingRepository2(repoMgr, bundle) {
             @Override
             protected Session createAdministrativeSession(String workspace) throws RepositoryException {
@@ -96,7 +98,7 @@ public class AllowListWiringTest {
             }
         };
     }
-    
+
     @Test
     @SuppressWarnings("deprecation")
     public void testLoginAdmin() throws Exception {
@@ -104,10 +106,10 @@ public class AllowListWiringTest {
         try {
             repository.loginAdministrative(null);
             allowed = true;
-        } catch(LoginException ignored) {
+        } catch (LoginException ignored) {
             allowed = false;
         }
-        
+
         assertEquals(loginAdminExpected, allowed);
     }
 }

--- a/src/test/java/org/apache/sling/jcr/base/internal/LegacyFragmentTest.java
+++ b/src/test/java/org/apache/sling/jcr/base/internal/LegacyFragmentTest.java
@@ -18,28 +18,25 @@
  */
 package org.apache.sling.jcr.base.internal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.osgi.util.converter.Converters;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class LegacyFragmentTest {
 
     private final LegacyFragment.Configuration configuration;
+
     {
         final Map<String, Object> props = new HashMap<>();
         props.put("whitelist.name", "test");
-        props.put("whitelist.bundles", new String[] { "org.apache.sling.test" });
-        configuration = Converters.standardConverter()
-                .convert(props)
-                .to(LegacyFragment.Configuration.class);
+        props.put("whitelist.bundles", new String[] {"org.apache.sling.test"});
+        configuration = Converters.standardConverter().convert(props).to(LegacyFragment.Configuration.class);
     }
 
     @Test
@@ -54,7 +51,8 @@ public class LegacyFragmentTest {
     @Test
     public void testEquality() {
         final LegacyFragment legacyFragment = new LegacyFragment(configuration);
-        final AllowListFragment fragment = new AllowListFragment(configuration.whitelist_name(), configuration.whitelist_bundles());
+        final AllowListFragment fragment =
+                new AllowListFragment(configuration.whitelist_name(), configuration.whitelist_bundles());
 
         assertEquals(fragment, legacyFragment);
     }

--- a/src/test/java/org/apache/sling/jcr/base/internal/LoginAdminAllowListTest.java
+++ b/src/test/java/org/apache/sling/jcr/base/internal/LoginAdminAllowListTest.java
@@ -18,11 +18,6 @@
  */
 package org.apache.sling.jcr.base.internal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
-
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
@@ -35,6 +30,11 @@ import org.mockito.Mockito;
 import org.osgi.framework.Bundle;
 import org.osgi.service.cm.ConfigurationException;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
 public class LoginAdminAllowListTest {
 
     private LoginAdminAllowList allowList;
@@ -43,17 +43,17 @@ public class LoginAdminAllowListTest {
     public void setup() {
         allowList = new LoginAdminAllowList();
     }
-    
+
     private void assertAdminLogin(final String bundleSymbolicName, boolean expected) {
         final Bundle b = Mockito.mock(Bundle.class);
         when(b.getSymbolicName()).thenReturn(bundleSymbolicName);
         final boolean actual = allowList.allowLoginAdministrative(b);
         assertEquals("For bundle " + bundleSymbolicName + ", expected admin login=" + expected, expected, actual);
     }
-    
+
     private List<String> randomBsn() {
         final List<String> result = new ArrayList<String>();
-        for(int i=0; i < 5; i++) {
+        for (int i = 0; i < 5; i++) {
             result.add("random.bsn." + UUID.randomUUID());
         }
         return result;
@@ -62,85 +62,78 @@ public class LoginAdminAllowListTest {
     @Test
     public void testBypassAllowList() throws ConfigurationException {
         configure(allowList, true, null, null, null);
-        
-        for(String bsn : randomBsn()) {
+
+        for (String bsn : randomBsn()) {
             assertAdminLogin(bsn, true);
         }
     }
-    
+
     @Test
     public void testDefaultConfigOnly() throws ConfigurationException {
-        final String [] allowed = {
-                "bundle1", "bundle2"
-        };
+        final String[] allowed = {"bundle1", "bundle2"};
         configure(allowList, null, null, allowed, null);
 
         assertAdminLogin("foo.1.bar", false);
 
-        for(String bsn : allowed) {
+        for (String bsn : allowed) {
             assertAdminLogin(bsn, true);
         }
 
-        for(String bsn : randomBsn()) {
+        for (String bsn : randomBsn()) {
             assertAdminLogin(bsn, false);
         }
     }
-    
+
     @Test
     public void testAdditionalConfigOnly() throws ConfigurationException {
-        final String [] allowed = {
-                "bundle5", "bundle6"
-        };
+        final String[] allowed = {"bundle5", "bundle6"};
         configure(allowList, null, null, null, allowed);
 
         assertAdminLogin("foo.1.bar", false);
 
-        for(String bsn : allowed) {
+        for (String bsn : allowed) {
             assertAdminLogin(bsn, true);
         }
 
-        for(String bsn : randomBsn()) {
+        for (String bsn : randomBsn()) {
             assertAdminLogin(bsn, false);
         }
     }
-    
+
     @Test
     public void testDefaultAndAdditionalConfig() throws ConfigurationException {
-        configure(allowList, null, null, new String [] { "defB"}, new String [] { "addB"});
-        
+        configure(allowList, null, null, new String[] {"defB"}, new String[] {"addB"});
+
         assertAdminLogin("defB", true);
         assertAdminLogin("addB", true);
         assertAdminLogin("foo.1.bar", false);
-        
-        for(String bsn : randomBsn()) {
+
+        for (String bsn : randomBsn()) {
             assertAdminLogin(bsn, false);
         }
     }
-    
+
     @Test
     public void testRegexpAllowList() throws ConfigurationException {
-        final String [] allowed = {
-                "bundle3", "bundle4"
-        };
+        final String[] allowed = {"bundle3", "bundle4"};
         configure(allowList, null, "foo.*bar", allowed, null);
 
         assertAdminLogin("foo.2.bar", true);
         assertAdminLogin("foo.somethingElse.bar", true);
 
-        for(String bsn : allowed) {
+        for (String bsn : allowed) {
             assertAdminLogin(bsn, true);
         }
-        
-        for(String bsn : randomBsn()) {
+
+        for (String bsn : randomBsn()) {
             assertAdminLogin(bsn, false);
         }
     }
 
-
     @Test
     public void testAllowListFragment() throws ConfigurationException {
-        final String [] allowed1 = randomBsn().toArray(new String[0]);
-        final String [] allowed2 = randomBsn().toArray(new String[0]);
+        final String[] allowed1 = randomBsn().toArray(new String[0]);
+        final String[] allowed2 = randomBsn().toArray(new String[0]);
 
         final AllowListFragment testFragment1 = new AllowListFragment("test1", allowed1);
         final AllowListFragment testFragment2 = new AllowListFragment("test2", allowed2);
@@ -149,30 +142,36 @@ public class LoginAdminAllowListTest {
         allowList.bindAllowListFragment(testFragment1);
         allowList.bindAllowListFragment(testFragment2);
 
-        for(String bsn : allowed1) {
+        for (String bsn : allowed1) {
             assertAdminLogin(bsn, true);
         }
 
-        for(String bsn : allowed2) {
+        for (String bsn : allowed2) {
             assertAdminLogin(bsn, true);
         }
 
-        for(String bsn : randomBsn()) {
+        for (String bsn : randomBsn()) {
             assertAdminLogin(bsn, false);
         }
 
         allowList.unbindAllowListFragment(testFragment1);
 
-        for(String bsn : allowed1) {
+        for (String bsn : allowed1) {
             assertAdminLogin(bsn, false);
         }
 
-        for(String bsn : allowed2) {
+        for (String bsn : allowed2) {
             assertAdminLogin(bsn, true);
         }
     }
 
-    private void configure(final LoginAdminAllowList allowList, final Boolean bypass, final String regexp, final String[] defaultBSNs, final String[] additionalBSNs) throws ConfigurationException {
+    private void configure(
+            final LoginAdminAllowList allowList,
+            final Boolean bypass,
+            final String regexp,
+            final String[] defaultBSNs,
+            final String[] additionalBSNs)
+            throws ConfigurationException {
         final Hashtable<String, Object> props = new Hashtable<>();
         if (bypass != null) {
             props.put("allowlist.bypass", bypass);

--- a/src/test/java/org/apache/sling/jcr/base/util/AccessControlUtilTest.java
+++ b/src/test/java/org/apache/sling/jcr/base/util/AccessControlUtilTest.java
@@ -18,13 +18,13 @@
  */
 package org.apache.sling.jcr.base.util;
 
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import org.apache.sling.testing.mock.jcr.MockJcr;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.apache.sling.testing.mock.jcr.MockJcr;
-
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 
 public class AccessControlUtilTest {
 

--- a/src/test/java/org/apache/sling/jcr/base/util/ConfigAnnotationUtil.java
+++ b/src/test/java/org/apache/sling/jcr/base/util/ConfigAnnotationUtil.java
@@ -18,10 +18,6 @@
  */
 package org.apache.sling.jcr.base.util;
 
-import org.osgi.service.cm.ConfigurationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -31,6 +27,10 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
 
+import org.osgi.service.cm.ConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /** TODO move this to a testing utilities module? */
 public class ConfigAnnotationUtil {
 
@@ -39,8 +39,8 @@ public class ConfigAnnotationUtil {
     @SuppressWarnings("unchecked")
     public static <T> T fromDictionary(final Class<T> clazz, final Dictionary<String, ?> properties)
             throws ConfigurationException {
-        return (T)Proxy.newProxyInstance(clazz.getClassLoader(), new Class[]{ clazz },
-                new Handler(copyAndVerify(properties, clazz)));
+        return (T) Proxy.newProxyInstance(
+                clazz.getClassLoader(), new Class[] {clazz}, new Handler(copyAndVerify(properties, clazz)));
     }
 
     private static class Handler implements InvocationHandler {
@@ -101,7 +101,8 @@ public class ConfigAnnotationUtil {
             final Class<?> valueClass = value.getClass();
             if (!isAssignable(returnType, valueClass)) {
                 LOG.error("Invalid value type for {} ({} instead of {})", propertyName, valueClass, returnType);
-                throw new ConfigurationException(propertyName,
+                throw new ConfigurationException(
+                        propertyName,
                         "Value of incorrect type " + valueClass.getName() + " instead of " + returnType.getName());
             }
         }
@@ -134,6 +135,7 @@ public class ConfigAnnotationUtil {
     }
 
     private static final Map<Class<?>, Class<?>> primitiveToWrapper = new HashMap<Class<?>, Class<?>>();
+
     static {
         primitiveToWrapper.put(Boolean.TYPE, Boolean.class);
         primitiveToWrapper.put(Byte.TYPE, Byte.class);


### PR DESCRIPTION
Upgrades the Maven parent POM and applies consistent formatting across the module.

**Changes:**
- Bump `sling-bundle-parent` from version 52 to 66
- Add `<sling.java.version>8</sling.java.version>` property
- Reorder imports (javax before java, then org.*) to match Google Java Style
- Reformat Javadoc comments to use `<p>` tags and consistent line wrapping
- Move `<build>` section after `<dependencies>` for standard POM ordering
- Fix `<scm>` block indentation and inline `<tag>HEAD</tag>`
- Inline `<description>` to a single line
- Remove maven-javadoc-plugin's multi-line `<excludePackageNames>` in favour of single-line value
- No functional or behavioural changes; diff was truncated at 46 files

Co-authored-by: Maia <maia@noreply>