### PR TITLE
docs: update AGENTS.md and README.md with additional test classes and constraints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Project Overview
 
-`org.apache.sling.jcr.base` is an OSGi bundle that provides JCR foundation classes for Apache Sling. It includes base classes for implementing `SlingRepository` (`AbstractSlingRepository2`, `AbstractSlingRepositoryManager`), `loginAdministrative` allow-list enforcement via OSGi component configuration, repository initializer execution (`SlingRepositoryInitializer` services), JCR node-type/namespace loading utilities, access-control helpers, and a proxy/mount layer that lets multiple JCR repositories appear as one. Components are wired at runtime via the OSGi service registry.
+`org.apache.sling.jcr.base` is an OSGi bundle that provides JCR foundation classes for Apache Sling. It includes base classes for implementing `SlingRepository` (`AbstractSlingRepository2`, `AbstractSlingRepositoryManager`), `loginAdministrative` allow-list enforcement via OSGi component configuration, repository initializer execution (`SlingRepositoryInitializer` services), JCR node-type/namespace loading utilities, access-control helpers, repository Web Console status printers, and a proxy/mount layer that lets multiple JCR repositories appear as one. Components are wired at runtime via the OSGi service registry.
 
 # Core Commands
 
@@ -22,6 +22,12 @@ mvn test -Dtest=LoginAdminAllowListTest
 
 # Run a single test method
 mvn test -Dtest=LoginAdminAllowListTest#testAllowList
+
+# Additional focused test classes
+mvn test -Dtest=RepositoryInitializersTest
+mvn test -Dtest=RepositoryMountTest
+mvn test -Dtest=NodeTypeLoaderTest
+mvn test -Dtest=AccessControlUtilTest
 
 # Lint / code style (Spotless + RAT)
 mvn spotless:check
@@ -70,6 +76,7 @@ target/                          Build output (gitignored)
 # Development Patterns & Constraints
 
 - **Java 8** source/target (`sling.java.version=8` in pom.xml). Do not use APIs above Java 8.
+- **Sling parent POM**: inherited from `org.apache.sling:sling-bundle-parent:66`; keep plugin/config conventions aligned with the parent.
 - **OSGi DS annotations only**: use `org.osgi.service.component.annotations.*` and `org.osgi.service.metatype.annotations.*`. No Felix SCR annotations.
 - **4-space indentation**, no tabs. Spotless (Eclipse formatter) enforces this — run `mvn spotless:apply` after edits.
 - Internal implementation classes live under `*.internal.*` packages; these are not exported and must not be referenced from outside.
@@ -78,6 +85,7 @@ target/                          Build output (gitignored)
 - All source files require the Apache License 2.0 header; RAT enforces this.
 - The `bnd.bnd` file declares `Import-Package` overrides (e.g., optional RMI import). Keep it in sync when adding new optional dependencies.
 - Repository initializer execution order follows OSGi service ranking (`SlingRepositoryInitializer` with higher ranking runs first).
+- Mount integration uses one active `RepositoryMount`; if multiple services exist, highest OSGi service ranking wins.
 
 # Git Workflow
 
@@ -92,8 +100,11 @@ target/                          Build output (gitignored)
 - Framework: **JUnit 4** with Mockito 5 and Sling OSGi Mock / Sling Mock / JCR Mock
 - Test files mirror main sources under `src/test/java/…`
 - OSGi component tests use `OsgiContext` (from `org.apache.sling.testing.osgi-mock.junit4`)
+- `NodeTypeLoaderTest` validates built-in node type re-registration detection logic.
 - `RepositoryInitializersTest` covers initializer ordering and repository registration failure paths.
+- `RepositoryMountTest` covers mount registration lifecycle and path delegation behavior.
 - Allow-list behavior is covered by `LoginAdminAllowListTest`, `AllowListWiringTest`, and `LegacyFragmentTest`.
+- `AccessControlUtilTest` validates reflective ACL access helper behavior against mock JCR sessions.
 - Run coverage: `mvn test jacoco:report` (JaCoCo is inherited from the Sling bundle parent POM)
 - Coverage report appears in `target/site/jacoco/`
 
@@ -104,6 +115,7 @@ target/                          Build output (gitignored)
 - **OSGi mock version matters**: the tests use `osgi-mock.junit4` 3.x; mixing with 2.x artefacts breaks context setup.
 - **RMI dependency is optional**: `jackrabbit-jcr-rmi` is `provided` scope and the Import-Package is `resolution:=optional`. Do not make it mandatory.
 - **Repository startup is blocked on initializer failures**: exceptions/errors from `SlingRepositoryInitializer` prevent SlingRepository service registration.
+- **Only one repository mount is active at a time**: mount service selection follows OSGi ranking, so tests and debugging should account for service ordering.
 - **Baseline check**: the parent POM runs OSGi semantic-version baseline against the previous release JAR. Adding API without bumping the package version will fail the build.
 - **Spotless must pass before RAT**: run `mvn spotless:apply` before committing; otherwise the RAT XML-header check may report false positives on reformatted files.
 - The `internal` packages are deliberately excluded from Javadoc generation (see `pom.xml` `maven-javadoc-plugin` config).
@@ -113,4 +125,3 @@ target/                          Build output (gitignored)
 <!-- sling-security-default:start -->
 The threat model for this project is https://github.com/apache/sling/blob/master/docs/threat-model.md .
 <!-- sling-security-default:end -->
-

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This module is part of the [Apache Sling](https://sling.apache.org) project.
 
-The JCR base bundle provides JCR utility classes, base implementations for `SlingRepository`, login administrative allow-list enforcement, repository initializer execution, node type and namespace loading helpers, repository status printer support, and repository mount integration for JCR-based legacy access.
+The JCR base bundle provides JCR utility classes, base implementations for `SlingRepository`, `loginAdministrative` allow-list enforcement, repository initializer execution, node type and namespace loading helpers, repository status printer support, and repository mount integration for JCR-based legacy access.
 
 # Build
 
@@ -25,6 +25,9 @@ mvn test
 mvn test -Dtest=LoginAdminAllowListTest
 mvn test -Dtest=LoginAdminAllowListTest#testAllowList
 mvn test -Dtest=RepositoryInitializersTest
+mvn test -Dtest=RepositoryMountTest
+mvn test -Dtest=NodeTypeLoaderTest
+mvn test -Dtest=AccessControlUtilTest
 ```
 
 ```bash
@@ -49,6 +52,7 @@ mvn javadoc:javadoc
 * Maven build for an OSGi bundle (Sling bundle parent)
 * OSGi Declarative Services and Metatype annotations (`org.osgi.service.component.annotations`, `org.osgi.service.metatype.annotations`)
 * Optional Jackrabbit RMI support via `jackrabbit-jcr-rmi` (provided scope, optional package import)
+* JUnit 4 with Sling OSGi/Sling/JCR mock test tooling and Mockito for tests
 
 # Main Components
 
@@ -62,8 +66,8 @@ mvn javadoc:javadoc
 
 # Project Structure
 
-* `src/main/java` - bundle implementation and SPI
-* `src/test/java` - JUnit 4 + Sling testing mocks
+* `src/main/java/org/apache/sling/jcr/base` - bundle implementation, internal services, SPI, and utility classes
+* `src/test/java` - JUnit 4 tests mirroring package structure with Sling testing mocks
 * `pom.xml` - Maven build (Sling bundle parent)
 * `bnd.bnd` - OSGi manifest instructions
 
@@ -114,3 +118,9 @@ When present, the following bundle manifest headers are processed to register re
 Services implementing `org.apache.sling.jcr.api.SlingRepositoryInitializer` are executed at repository startup before the repository service is registered.
 
 If an initializer throws an exception or error, repository service registration is aborted.
+
+# Security
+
+This module follows the Apache Sling threat model:
+
+https://github.com/apache/sling/blob/master/docs/threat-model.md


### PR DESCRIPTION
Improves documentation accuracy and completeness for the `org.apache.sling.jcr.base` bundle.

- Add `RepositoryMountTest`, `NodeTypeLoaderTest`, and `AccessControlUtilTest` to focused test command examples in both AGENTS.md and README.md
- Mention repository Web Console status printers in the project overview
- Document Sling parent POM version (`sling-bundle-parent:66`) in development constraints
- Add mount integration constraint: only one active `RepositoryMount` at a time, selected by OSGi service ranking
- Expand testing section with descriptions for `NodeTypeLoaderTest`, `RepositoryMountTest`, and `AccessControlUtilTest`
- Add pitfall entry for single active repository mount and service ordering
- Clarify `src/main/java` path and test tooling details in README.md project structure
- Add JUnit 4 / Sling mock tooling to README.md technology list
- Add Security section to README.md linking to the Apache Sling threat model
- Fix minor wording: `login administrative allow-list` → `loginAdministrative allow-list`
- Remove trailing blank line at end of AGENTS.md

Co-authored-by: Maia <maia@noreply>